### PR TITLE
Wire live Solana payments, IPFS storage, and on-chain listing registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Screen Sync — environment configuration
+#
+# Copy this file to `.env.local` for local development:
+#     cp .env.example .env.local
+# Then fill in the values below. For production, set the SAME variables in the
+# Netlify dashboard (Site settings -> Environment variables).
+#
+# Leaving a value blank keeps that integration in MOCK mode, so the app runs
+# locally with no setup. Real behaviour activates automatically once set.
+#
+# The dApp is database-free: listings live on IPFS with their CID anchored
+# on-chain, and are discovered by reading the treasury account's tx history.
+#
+# See docs/BACKEND-SETUP.md for step-by-step instructions on obtaining each value.
+
+# ---------------------------------------------------------------------------
+# Solana (public — safe to expose in the browser)
+# ---------------------------------------------------------------------------
+# RPC endpoint. Defaults to public devnet if unset. A dedicated RPC
+# (Helius / QuickNode) is recommended for production reliability + faster reads.
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+NEXT_PUBLIC_SOLANA_CLUSTER=devnet
+
+# Treasury wallet PUBLIC address that receives payments AND acts as the on-chain
+# listing registry (we scan its tx history to discover listings).
+# This is a public receiving address — NEVER put a private key or seed phrase here.
+# Until set, payments + on-chain listing persistence stay mocked.
+NEXT_PUBLIC_TREASURY_ADDRESS=
+
+# ---------------------------------------------------------------------------
+# IPFS / Pinata
+# ---------------------------------------------------------------------------
+# Public gateway used for READS (safe to expose).
+NEXT_PUBLIC_IPFS_GATEWAY=https://gateway.pinata.cloud/ipfs
+
+# SECRET — server-side only. Used by /api/upload + /api/pin-json to pin media
+# and listing metadata. Never prefix with NEXT_PUBLIC.
+# Until set, uploads return a mock CID (listings won't be readable back).
+PINATA_JWT=

--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,17 @@
 NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
 NEXT_PUBLIC_SOLANA_CLUSTER=devnet
 
-# Treasury wallet PUBLIC address that receives payments AND acts as the on-chain
-# listing registry (we scan its tx history to discover listings).
+# Treasury wallet PUBLIC address that receives payments (USDC bookings + SOL
+# listing fees) AND acts as the on-chain registry (we scan its tx history to
+# discover listings and bookings, including what /api/ad serves).
 # This is a public receiving address — NEVER put a private key or seed phrase here.
-# Until set, payments + on-chain listing persistence stay mocked.
+# Until set, payments + on-chain persistence stay mocked.
 NEXT_PUBLIC_TREASURY_ADDRESS=
+
+# USDC mint for booking payments. Defaults to Circle's DEVNET USDC
+# (test tokens: https://faucet.circle.com). For mainnet later:
+# NEXT_PUBLIC_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+NEXT_PUBLIC_USDC_MINT=
 
 # ---------------------------------------------------------------------------
 # IPFS / Pinata

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ List your screen. Book attention. Settle instantly — all on-chain.
 
 Screen Sync turns ad inventory into a tradeable, on-chain marketplace. Advertisers browse and book real-world and digital ad placements directly from inventory owners — no middlemen, transparent pricing, instant settlement.
 
-This repository contains the **frontend dApp** (UI). It currently runs on **mock data** with stubbed on-chain and IPFS calls, architected so the live Solana program and Pinata integration can be wired in without UI changes.
+This repository contains the **dApp**. The hybrid MVP backend is wired: **real SOL
+payments** (devnet), **real IPFS media** (Pinata), and a **database-free** listing
+model where listing metadata lives on IPFS with its CID anchored on-chain. With no
+configuration it runs in **mock mode** (demo data, no keys needed); adding a treasury
+address + Pinata key flips it live. See [`docs/BACKEND-SETUP.md`](docs/BACKEND-SETUP.md).
 
 ### Inventory types
 🎮 Video Game · 📺 Billboard · 📡 Stream/TV · 🌐 Website ·  🛸 Mobile · 🏪 Storefront
@@ -34,18 +38,20 @@ This repository contains the **frontend dApp** (UI). It currently runs on **mock
 
 Screen Sync runs a **hybrid Solana + IPFS** model today, deliberately designed as a stepping stone toward a **fully on-chain protocol**.
 
-**Today (hybrid):**
-- **Listings, bookings & settlement** → on-chain (Solana program)
-- **Ad creatives & media** → IPFS via Pinata; the resulting content ID (CID) is recorded in the on-chain account, so the media is content-addressed and tamper-evident even while pinning is delegated
+**Today (hybrid MVP — database-free):**
+- **Payments** → real SOL transfers on devnet (booking + listing registration), via the connected wallet, with an on-chain memo describing the deal.
+- **Listings** → metadata pinned to IPFS; the CID is anchored on-chain via the registration tx. Listings are **discovered by scanning the treasury account's tx history** — no backend database. The treasury doubles as the on-chain registry.
+- **Ad creatives & media** → IPFS via Pinata; the CID is content-addressed and tamper-evident.
+- **Source of truth = chain + IPFS.** Off-chain pieces (RPC, Pinata) are caches/services, not the system of record.
 
-**The intent — gradually go fully on-chain.** The hybrid split exists because large media and rich state are impractical/expensive to put directly on-chain right now. As tooling and costs improve, we migrate responsibilities on-chain in phases:
+**The intent — gradually go fully on-chain**, in phases:
 
-1. **Phase 1 (current):** on-chain listings + settlement, media on IPFS/Pinata (CID anchored on-chain).
-2. **Phase 2:** decentralize pinning (multiple pinning providers / Arweave permanence) and move more booking/escrow logic into the program.
-3. **Phase 3:** on-chain proof-of-display and dispute resolution against immutable records.
+1. **Phase 1 (current):** real SOL payments; listings = IPFS metadata + on-chain CID; discovery via chain scan.
+2. **Phase 2:** Anchor program for **trustless escrow/refunds**, an on-chain availability ledger, and a fast read **indexer** (Helius/DAS) as a cache.
+3. **Phase 3:** on-chain proof-of-display + dispute resolution; ad-serving SDK/oracle.
 4. **Phase 4:** fully on-chain protocol — minimize off-chain trust to indexing/RPC only.
 
-All chain/IPFS calls are currently stubbed in [`lib/solana.ts`](lib/solana.ts) and [`lib/pinata.ts`](lib/pinata.ts) so the UI works on mock data and the real integrations drop in without UI changes.
+Integration code lives in [`lib/transactions.ts`](lib/transactions.ts), [`lib/listings.ts`](lib/listings.ts), [`lib/solana.ts`](lib/solana.ts), [`lib/pinata.ts`](lib/pinata.ts), and the API routes under `app/api/`. Every integration falls back to mock when its env vars are absent, so the UI never depends on configuration.
 
 ---
 
@@ -53,10 +59,16 @@ All chain/IPFS calls are currently stubbed in [`lib/solana.ts`](lib/solana.ts) a
 
 ```bash
 npm install
-npm run dev
+npm run dev          # http://localhost:3001 — runs in mock mode, no setup needed
 ```
 
-Open [http://localhost:3001](http://localhost:3001).
+To go live (real payments + IPFS), copy the env template and fill it in:
+
+```bash
+cp .env.example .env.local
+```
+
+See [`docs/BACKEND-SETUP.md`](docs/BACKEND-SETUP.md) for the (short) list of values you provide.
 
 A Solana wallet (Phantom or Solflare) browser extension is needed to test wallet-gated pages (Dashboard, List Inventory).
 
@@ -70,19 +82,23 @@ app/                    # Next.js App Router pages
   marketplace/          # Browse + listing detail
   dashboard/            # Wallet-gated account view
   list/                 # Multi-step create-listing flow
+  api/                  # Server routes: /api/upload, /api/pin-json (Pinata, server-side)
 components/             # Reusable UI components
-lib/                    # Mock data + Solana/Pinata stubs
+lib/                    # config, connection, transactions, listings, pinata, pricing, mock seed
 styles/                 # CSS Modules
+docs/                   # BACKEND-SETUP.md (your manual inputs), SMART-CONTRACTS.md (Phase 2)
 ```
 
 ---
 
 ## Roadmap
 
-- [ ] Deploy Solana program & wire `lib/solana.ts`
-- [ ] Live Pinata uploads in `lib/pinata.ts`
-- [ ] Real booking + escrow flow
-- [ ] On-chain analytics dashboard
+- [x] Real SOL payments (booking + listing registration) on devnet
+- [x] Live Pinata uploads (media + metadata) via server-side routes
+- [x] Database-free listings (IPFS metadata + on-chain CID, discovered by chain scan)
+- [ ] Anchor program: trustless escrow/refunds + on-chain availability ledger
+- [ ] Read indexer (Helius/DAS) as a cache for fast browse at scale
+- [ ] On-chain proof-of-display + ad-serving SDK/oracle
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ address + Pinata key flips it live. See [`docs/BACKEND-SETUP.md`](docs/BACKEND-S
 
 Screen Sync runs a **hybrid Solana + IPFS** model today, deliberately designed as a stepping stone toward a **fully on-chain protocol**.
 
-**Today (hybrid MVP — database-free):**
-- **Payments** → real SOL transfers on devnet (booking + listing registration), via the connected wallet, with an on-chain memo describing the deal.
-- **Listings** → metadata pinned to IPFS; the CID is anchored on-chain via the registration tx. Listings are **discovered by scanning the treasury account's tx history** — no backend database. The treasury doubles as the on-chain registry.
+**Today (self-contained hybrid MVP — database-free):**
+- **The product** → Screen Sync sells its **own** ad space (the `house_web` listing, live on the marketing site): flat **$20 USDC** exclusive **15-minute slots** (UTC) + frequency filler ($5/$10/$20 per day, Low/Medium/High rotation share).
+- **Payments** → real **USDC** transfers on devnet from the advertiser's wallet to the treasury, with an on-chain memo carrying the booking terms **and the creative's IPFS CID**. Listing registration anchors with a small SOL memo tx.
+- **Availability** → booked slots are read back from the treasury's on-chain history — the calendar shows real occupancy and slots can't be double-sold.
+- **Serving** → the marketing website embeds [`public/tag.js`](public/tag.js), which asks [`/api/ad`](app/api/ad/route.ts) what's booked for the current 15-min window: exclusive slot → weighted filler rotation → house ad.
 - **Ad creatives & media** → IPFS via Pinata; the CID is content-addressed and tamper-evident.
-- **Source of truth = chain + IPFS.** Off-chain pieces (RPC, Pinata) are caches/services, not the system of record.
+- **Source of truth = chain + IPFS.** Off-chain pieces (RPC, Pinata) are caches/services, not the system of record. No database anywhere.
 
 **The intent — gradually go fully on-chain**, in phases:
 

--- a/app/api/ad/route.ts
+++ b/app/api/ad/route.ts
@@ -1,0 +1,113 @@
+// Ad decision endpoint — the serving plane of the MVP.
+//
+// The website's tag.js calls this to learn which creative to show right now:
+//   1. If an exclusive 15-min slot (UTC) is booked for the current window,
+//      serve that creative.
+//   2. Otherwise rotate through active filler bookings, weighted by tier
+//      (low 1×, medium 2×, high 4×), interleaved with the house ad.
+//   3. Otherwise serve the house ad.
+//
+// Bookings are read straight from the treasury's on-chain history (60s cache
+// in lib/bookings) — no database. CORS is open: the marketing site lives on a
+// different origin, and the response contains only public on-chain data.
+import { NextRequest, NextResponse } from 'next/server';
+import { SLOT_MINUTES, FILLER_TIERS } from '@/lib/constants';
+import { HOUSE_LISTING_ID } from '@/lib/mockData';
+import { getListingBookings, bookedSlotSet, activeFillers } from '@/lib/bookings';
+import { IPFS_GATEWAY } from '@/lib/config';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  // Let CDNs cache briefly; decisions change at most once per rotation.
+  'Cache-Control': 'public, max-age=0, s-maxage=30',
+};
+
+/** House fallback ad — shown when nothing is booked. */
+const HOUSE_AD = {
+  kind: 'house' as const,
+  imageUrl: '/listings/lst_004.jpg',
+  clickUrl: `/marketplace/${HOUSE_LISTING_ID}`,
+  headline: 'This ad space is for sale — book it on-chain',
+};
+
+/** Rotation window for filler (seconds). Each window may show a different ad. */
+const ROTATION_SECONDS = 60;
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}
+
+export async function GET(req: NextRequest) {
+  const listingId = req.nextUrl.searchParams.get('listing') || HOUSE_LISTING_ID;
+  const origin = req.nextUrl.origin;
+
+  const absolute = (u: string) => (u.startsWith('http') ? u : `${origin}${u}`);
+  const house = {
+    ...HOUSE_AD,
+    imageUrl: absolute(HOUSE_AD.imageUrl),
+    clickUrl: absolute(HOUSE_AD.clickUrl),
+  };
+
+  try {
+    const bookings = await getListingBookings(listingId);
+    const now = new Date();
+    const dateISO = now.toISOString().slice(0, 10); // UTC date
+    const slotIdx = Math.floor((now.getUTCHours() * 60 + now.getUTCMinutes()) / SLOT_MINUTES);
+
+    // 1. Exclusive slot for the current window wins outright.
+    const slotBooking = bookings.find(
+      (b) => b.mode === 'slot' && b.dateISO === dateISO && b.slots!.includes(slotIdx)
+    );
+    if (slotBooking) {
+      return NextResponse.json(
+        {
+          kind: 'slot',
+          imageUrl: `${IPFS_GATEWAY}/${slotBooking.creativeCid}`,
+          clickUrl: house.clickUrl,
+          cid: slotBooking.creativeCid,
+          window: { dateISO, slotIdx },
+        },
+        { headers: CORS }
+      );
+    }
+
+    // 2. Weighted filler rotation, interleaved with the house ad.
+    const fillers = activeFillers(bookings, dateISO);
+    if (fillers.length > 0) {
+      const weightOf = (t: string) => FILLER_TIERS.find((x) => x.id === t)?.weight ?? 1;
+      // House ad keeps a share of rotations equal to the heaviest tier.
+      const houseWeight = Math.max(...FILLER_TIERS.map((t) => t.weight));
+      const total = fillers.reduce((s, f) => s + weightOf(f.tier!), 0) + houseWeight;
+      // Deterministic rotation: same choice within a window, advances each window.
+      const windowIdx = Math.floor(now.getTime() / (ROTATION_SECONDS * 1000));
+      let pick = windowIdx % total;
+      for (const f of fillers) {
+        pick -= weightOf(f.tier!);
+        if (pick < 0) {
+          return NextResponse.json(
+            {
+              kind: 'filler',
+              imageUrl: `${IPFS_GATEWAY}/${f.creativeCid}`,
+              clickUrl: house.clickUrl,
+              cid: f.creativeCid,
+              tier: f.tier,
+            },
+            { headers: CORS }
+          );
+        }
+      }
+      // Fall through → house ad's turn in the rotation.
+    }
+
+    // 3. Nothing booked (or house's rotation turn).
+    const taken = bookedSlotSet(bookings, dateISO).size;
+    return NextResponse.json({ ...house, bookedSlotsToday: taken }, { headers: CORS });
+  } catch (e) {
+    console.error('[Screen Sync] /api/ad failed', e);
+    return NextResponse.json(house, { headers: CORS });
+  }
+}

--- a/app/api/pin-json/route.ts
+++ b/app/api/pin-json/route.ts
@@ -1,0 +1,51 @@
+// Pins listing metadata JSON to IPFS via Pinata (server-side; keeps JWT off the
+// client). Falls back to a mock CID when PINATA_JWT is not configured.
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const PINATA_JWT = process.env.PINATA_JWT || '';
+const PINATA_JSON_URL = 'https://api.pinata.cloud/pinning/pinJSONToIPFS';
+const MAX_METADATA_BYTES = 50_000;
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Expected a JSON object' }, { status: 400 });
+  }
+  if (JSON.stringify(body).length > MAX_METADATA_BYTES) {
+    return NextResponse.json({ error: 'Metadata too large' }, { status: 400 });
+  }
+
+  // Mock fallback — lets the create flow run before Pinata is configured.
+  if (!PINATA_JWT) {
+    const mockCid = `QmMock${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
+    return NextResponse.json({ cid: mockCid, mock: true });
+  }
+
+  try {
+    const res = await fetch(PINATA_JSON_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${PINATA_JWT}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ pinataContent: body }),
+    });
+    if (!res.ok) {
+      console.error('[Pinata] pinJSON failed', res.status, await res.text().catch(() => ''));
+      return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+    }
+    const data = (await res.json()) as { IpfsHash?: string };
+    if (!data.IpfsHash) return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+    return NextResponse.json({ cid: data.IpfsHash });
+  } catch (e) {
+    console.error('[Pinata] pinJSON error', e);
+    return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+  }
+}

--- a/app/api/pin-json/route.ts
+++ b/app/api/pin-json/route.ts
@@ -9,6 +9,12 @@ const PINATA_JSON_URL = 'https://api.pinata.cloud/pinning/pinJSONToIPFS';
 const MAX_METADATA_BYTES = 50_000;
 
 export async function POST(req: NextRequest) {
+  // Reject oversized bodies before parsing them into memory (DoS guard).
+  const contentLength = Number(req.headers.get('content-length') || 0);
+  if (contentLength > MAX_METADATA_BYTES + 4096) {
+    return NextResponse.json({ error: 'Metadata too large' }, { status: 413 });
+  }
+
   let body: unknown;
   try {
     body = await req.json();

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -21,6 +21,12 @@ function validate(type: string, header: Uint8Array, size: number): string | null
 }
 
 export async function POST(req: NextRequest) {
+  // Reject oversized bodies before reading them into memory (DoS guard).
+  const contentLength = Number(req.headers.get('content-length') || 0);
+  if (contentLength > MAX_FILE_SIZE + 4096) {
+    return NextResponse.json({ error: 'File too large' }, { status: 413 });
+  }
+
   let file: File | null = null;
   try {
     const form = await req.formData();
@@ -31,7 +37,11 @@ export async function POST(req: NextRequest) {
   }
   if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
 
-  const header = new Uint8Array((await file.arrayBuffer()).slice(0, 4));
+  // Check size before reading the body; read only the first bytes for the magic check.
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: 'File too large' }, { status: 413 });
+  }
+  const header = new Uint8Array(await file.slice(0, 4).arrayBuffer());
   const err = validate(file.type, header, file.size);
   if (err) return NextResponse.json({ error: err }, { status: 400 });
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,66 @@
+// Server-side IPFS upload route. Keeps the Pinata JWT off the client and
+// re-validates the file (size / MIME / magic bytes) before pinning.
+// Falls back to a mock CID when PINATA_JWT is not configured.
+import { NextRequest, NextResponse } from 'next/server';
+import { FILE_SIGNATURES, MAX_FILE_SIZE } from '@/lib/constants';
+
+export const runtime = 'nodejs';
+
+const PINATA_JWT = process.env.PINATA_JWT || '';
+const PINATA_PIN_URL = 'https://api.pinata.cloud/pinning/pinFileToIPFS';
+
+/** Server-side mirror of lib/fileValidation — never trust the client. */
+function validate(type: string, header: Uint8Array, size: number): string | null {
+  if (size > MAX_FILE_SIZE) {
+    return `File exceeds the ${(MAX_FILE_SIZE / (1024 * 1024)).toFixed(0)}MB limit`;
+  }
+  const expected = FILE_SIGNATURES[type];
+  if (!expected) return 'Unsupported file type';
+  const ok = expected.every((byte, i) => header[i] === byte);
+  return ok ? null : 'File content does not match its type';
+}
+
+export async function POST(req: NextRequest) {
+  let file: File | null = null;
+  try {
+    const form = await req.formData();
+    const f = form.get('file');
+    if (f instanceof File) file = f;
+  } catch {
+    return NextResponse.json({ error: 'Invalid upload' }, { status: 400 });
+  }
+  if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+
+  const header = new Uint8Array((await file.arrayBuffer()).slice(0, 4));
+  const err = validate(file.type, header, file.size);
+  if (err) return NextResponse.json({ error: err }, { status: 400 });
+
+  // Mock fallback — lets the create-listing flow work before Pinata is set up.
+  if (!PINATA_JWT) {
+    const mockCid = `QmMock${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
+    return NextResponse.json({ cid: mockCid, mock: true });
+  }
+
+  try {
+    const pinForm = new FormData();
+    pinForm.append('file', file, file.name);
+    pinForm.append('pinataMetadata', JSON.stringify({ name: file.name }));
+
+    const res = await fetch(PINATA_PIN_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${PINATA_JWT}` },
+      body: pinForm,
+    });
+
+    if (!res.ok) {
+      console.error('[Pinata] pin failed', res.status, await res.text().catch(() => ''));
+      return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+    }
+    const data = (await res.json()) as { IpfsHash?: string };
+    if (!data.IpfsHash) return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+    return NextResponse.json({ cid: data.IpfsHash });
+  } catch (e) {
+    console.error('[Pinata] error', e);
+    return NextResponse.json({ error: 'Pinning failed' }, { status: 502 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,8 +2,9 @@
 
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { LISTINGS } from '@/lib/mockData';
+import type { Listing } from '@/lib/mockData';
+import { getBalance } from '@/lib/solana';
+import { getUserListings } from '@/lib/listings';
 import StatBox from '@/components/StatBox';
 import ListingCard from '@/components/ListingCard';
 import KickerLabel from '@/components/KickerLabel';
@@ -11,12 +12,22 @@ import Button from '@/components/Button';
 import WalletButton from '@/components/WalletButton';
 import styles from '@/styles/Dashboard.module.css';
 
-const MOCK_USER_LISTINGS = LISTINGS.slice(0, 3);
-
 export default function DashboardPage() {
   const { connected, publicKey } = useWallet();
   const [mounted, setMounted] = useState(false);
+  const [balance, setBalance] = useState<number | null>(null);
+  const [listings, setListings] = useState<Listing[]>([]);
+
   useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!publicKey) return;
+    const addr = publicKey.toBase58();
+    let active = true;
+    getBalance(addr).then((b) => { if (active) setBalance(b); }).catch(() => {});
+    getUserListings(addr).then((l) => { if (active) setListings(l); }).catch(() => {});
+    return () => { active = false; };
+  }, [publicKey]);
 
   if (!mounted) return null;
 
@@ -52,10 +63,10 @@ export default function DashboardPage() {
 
       <div className={styles.body}>
         <div className={styles.statsRow}>
-          <StatBox value={3} label="Active Listings" />
-          <StatBox value={42.69} label="SOL Balance" decimals={2} />
-          <StatBox value={258000} label="Total Impressions" />
-          <StatBox value={2} label="Active Campaigns" />
+          <StatBox value={listings.length} label="Active Listings" />
+          <StatBox value={balance ?? 0} label="SOL Balance" decimals={2} />
+          <StatBox value={listings.reduce((s, l) => s + l.impressionsPerDay, 0)} label="Impressions / Day" />
+          <StatBox value={0} label="Active Campaigns" />
         </div>
 
         <div className={styles.section}>
@@ -63,9 +74,15 @@ export default function DashboardPage() {
             <h2 className={styles.sectionTitle}>Your Listings</h2>
             <Button href="/list" variant="cherry" size="sm">+ List New</Button>
           </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 280px), 1fr))', gap: '1.5rem' }}>
-            {MOCK_USER_LISTINGS.map((l) => <ListingCard key={l.id} listing={l} />)}
-          </div>
+          {listings.length === 0 ? (
+            <p style={{ color: 'var(--beige-dim)', padding: '1.5rem 0', lineHeight: 1.6 }}>
+              You haven&apos;t registered any listings yet. Create one to see it here and in the marketplace.
+            </p>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 280px), 1fr))', gap: '1.5rem' }}>
+              {listings.map((l) => <ListingCard key={l.id} listing={l} />)}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/list/page.tsx
+++ b/app/list/page.tsx
@@ -3,7 +3,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { uploadToIPFS } from '@/lib/pinata';
-import { createListing } from '@/lib/solana';
+import { pinListingMetadata, listingMemo, type ListingMetadata } from '@/lib/listings';
+import { sendTreasuryTx } from '@/lib/transactions';
+import { PAYMENTS_ENABLED } from '@/lib/config';
+import { LISTING_FEE_SOL } from '@/lib/constants';
+import { txUrl } from '@/lib/explorer';
 import type { ListingType } from '@/lib/mockData';
 import { TYPE_LABELS, TYPE_ICONS } from '@/lib/mockData';
 import KickerLabel from '@/components/KickerLabel';
@@ -15,7 +19,7 @@ const ALL_TYPES = Object.keys(TYPE_LABELS) as ListingType[];
 const STEPS = ['Type', 'Details', 'Media', 'Submit'];
 
 export default function CreateListingPage() {
-  const { connected } = useWallet();
+  const { connected, publicKey, sendTransaction } = useWallet();
   const [mounted, setMounted] = useState(false);
   const [step, setStep] = useState(0);
   const [type, setType] = useState<ListingType | null>(null);
@@ -25,6 +29,7 @@ export default function CreateListingPage() {
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
   const [txHash, setTxHash] = useState('');
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -61,11 +66,45 @@ export default function CreateListingPage() {
   }
 
   async function handleSubmit() {
+    if (!publicKey) { setSubmitError('Wallet not connected'); return; }
     setSubmitting(true);
-    const tx = await createListing({ type: type!, ...form, ipfsCid: cid });
-    setTxHash(tx);
-    setStep(4);
-    setSubmitting(false);
+    setSubmitError('');
+    try {
+      // 1. Pin the listing metadata to IPFS.
+      const meta: ListingMetadata = {
+        v: 1,
+        type: type!,
+        title: form.title,
+        location: form.location,
+        pricePerDay: parseFloat(form.price) || 0,
+        description: form.description,
+        tags: [],
+        audience: '',
+        impressionsPerDay: 0,
+        publisherType: 'commercial',
+        mediaCid: cid,
+        owner: publicKey.toBase58(),
+        createdAt: Date.now(),
+      };
+      const metadataCid = await pinListingMetadata(meta);
+
+      // 2. Anchor the metadata CID on-chain (skipped in mock mode without a treasury).
+      let sig = '';
+      if (PAYMENTS_ENABLED) {
+        sig = await sendTreasuryTx({
+          payer: publicKey,
+          amountSol: LISTING_FEE_SOL,
+          memo: listingMemo(metadataCid),
+          sendTransaction,
+        });
+      }
+      setTxHash(sig);
+      setStep(4);
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
@@ -199,10 +238,16 @@ export default function CreateListingPage() {
                 <span style={{ fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: '0.9rem' }}>{v}</span>
               </div>
             ))}
+            <p style={{ color: 'var(--beige-dim)', fontSize: '0.8rem', marginTop: '1rem', lineHeight: 1.6 }}>
+              {PAYMENTS_ENABLED
+                ? `Registers your listing on-chain (≈ ${LISTING_FEE_SOL} SOL network/registry fee). Metadata is stored on IPFS.`
+                : 'Mock mode: metadata is pinned but no on-chain tx is sent (set a treasury address to go live).'}
+            </p>
+            {submitError && <div className={styles.uploadError}>⚠ {submitError}</div>}
             <div className={styles.actions} style={{ marginTop: '1.5rem' }}>
               <Button variant="ghost" onClick={() => setStep(2)}>← Back</Button>
               <Button variant="cherry" onClick={handleSubmit} disabled={submitting}>
-                {submitting ? 'Submitting…' : 'Submit On-Chain'}
+                {submitting ? 'Submitting…' : PAYMENTS_ENABLED ? 'Submit On-Chain' : 'Submit (Mock)'}
               </Button>
             </div>
           </div>
@@ -214,10 +259,19 @@ export default function CreateListingPage() {
             <div className={styles.successIcon}>✅</div>
             <div className={styles.successTitle}>Listing Submitted!</div>
             <p className={styles.successSub}>
-              Your listing has been submitted to the Solana devnet (mock). It will appear in the marketplace once confirmed on-chain.
+              {txHash
+                ? 'Your listing is registered on-chain and will appear in the marketplace.'
+                : 'Mock submission complete. Configure a treasury + Pinata to register on-chain.'}
             </p>
             <Button href="/" variant="cherry">Browse Marketplace</Button>
-            <div className={styles.mockTx}>Mock TX: {txHash}</div>
+            {txHash ? (
+              <a className={styles.mockTx} href={txUrl(txHash)} target="_blank" rel="noreferrer"
+                style={{ color: 'var(--cherry-bright)', textDecoration: 'underline' }}>
+                View transaction on Solana Explorer ↗
+              </a>
+            ) : (
+              <div className={styles.mockTx}>Mock submission (no on-chain tx)</div>
+            )}
           </div>
         )}
       </div>

--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
+import type { Listing } from '@/lib/mockData';
 import { LISTINGS, PUBLISHER_LABELS, listingImage } from '@/lib/mockData';
+import { getListingById } from '@/lib/listings';
 import TypeBadge from '@/components/TypeBadge';
 import KickerLabel from '@/components/KickerLabel';
 import ContractBuilder from '@/components/contract/ContractBuilder';
@@ -16,7 +19,23 @@ function fmtImpr(n: number): string {
 
 export default function ListingDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const listing = LISTINGS.find((l) => l.id === id);
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const seed = LISTINGS.find((l) => l.id === id);
+    if (seed) { setListing(seed); setLoading(false); return; }
+    let active = true;
+    setLoading(true);
+    getListingById(id)
+      .then((l) => { if (active) { setListing(l); setLoading(false); } })
+      .catch(() => { if (active) { setListing(null); setLoading(false); } });
+    return () => { active = false; };
+  }, [id]);
+
+  if (loading) {
+    return <div className={styles.notFound}><p>Loading listing…</p></div>;
+  }
 
   if (!listing) {
     return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Listing } from '@/lib/mockData';
 import { LISTINGS } from '@/lib/mockData';
+import { getAllListings } from '@/lib/listings';
 import ListingGrid from '@/components/ListingGrid';
 import KickerLabel from '@/components/KickerLabel';
 import styles from '@/styles/Marketplace.module.css';
 
 // The dApp opens straight on the listings — users arrive funneled from the
 // marketing site, so there's no separate landing/splash. Minimal friction.
+// Seed catalog renders instantly; on-chain listings merge in once loaded.
 export default function Home() {
+  const [listings, setListings] = useState<Listing[]>(LISTINGS);
+
+  useEffect(() => {
+    let active = true;
+    getAllListings()
+      .then((l) => { if (active) setListings(l); })
+      .catch(() => { /* keep seed catalog on error */ });
+    return () => { active = false; };
+  }, []);
+
   return (
     <div className={styles.page}>
       <div className={styles.header}>
         <KickerLabel>Marketplace</KickerLabel>
         <h1 className={styles.title}>Browse Ad Inventory</h1>
-        <p className={styles.meta}>{LISTINGS.length} listings · Devnet · Updated live</p>
+        <p className={styles.meta}>{listings.length} listings · Devnet · Updated live</p>
       </div>
       <div className={styles.body}>
-        <ListingGrid listings={LISTINGS} />
+        <ListingGrid listings={listings} />
       </div>
     </div>
   );

--- a/components/contract/AvailabilityCalendar.tsx
+++ b/components/contract/AvailabilityCalendar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { getDayStatus } from '@/lib/availability';
+import { getDayStatus, type DayStatus } from '@/lib/availability';
 import styles from '@/styles/ContractBuilder.module.css';
 
 const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -14,9 +14,11 @@ interface Props {
   isSelected: (dateISO: string) => boolean;
   inRange?: (dateISO: string) => boolean;
   onPick: (dateISO: string) => void;
+  /** Booking-aware day status (real on-chain occupancy). Falls back to the demo mock. */
+  dayStatus?: (dateISO: string) => DayStatus;
 }
 
-export default function AvailabilityCalendar({ listingId, isSelected, inRange, onPick }: Props) {
+export default function AvailabilityCalendar({ listingId, isSelected, inRange, onPick, dayStatus }: Props) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const [view, setView] = useState(new Date(today.getFullYear(), today.getMonth(), 1));
@@ -54,7 +56,7 @@ export default function AvailabilityCalendar({ listingId, isSelected, inRange, o
           if (!d) return <span key={i} />;
           const id = iso(d);
           const past = d < today;
-          const status = getDayStatus(listingId, id);
+          const status = dayStatus ? dayStatus(id) : getDayStatus(listingId, id);
           const disabled = past || status === 'full';
           const cls = [styles.day, styles[`day_${status}`]];
           if (disabled) cls.push(styles.dayDisabled);

--- a/components/contract/ContractBuilder.tsx
+++ b/components/contract/ContractBuilder.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import type { Listing } from '@/lib/mockData';
 import { FILLER_TIERS } from '@/lib/constants';
 import { slotBookingCost, fillerCost, type CostBreakdown } from '@/lib/pricing';
 import { getDaySlots, getFillerCapacity } from '@/lib/availability';
+import { sendTreasuryTx } from '@/lib/transactions';
+import { bookingMemo } from '@/lib/bookings';
+import { PAYMENTS_ENABLED } from '@/lib/config';
+import { txUrl } from '@/lib/explorer';
 import Button from '@/components/Button';
 import AvailabilityCalendar from './AvailabilityCalendar';
 import styles from '@/styles/ContractBuilder.module.css';
@@ -17,6 +22,7 @@ const daysBetween = (a: string, b: string) =>
 const ZERO: CostBreakdown = { subtotal: 0, fee: 0, total: 0 };
 
 export default function ContractBuilder({ listing }: { listing: Listing }) {
+  const { connected, publicKey, sendTransaction } = useWallet();
   const [mode, setMode] = useState<Mode>('slot');
 
   // Slot mode
@@ -30,6 +36,8 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
 
   const [signing, setSigning] = useState(false);
   const [signed, setSigned] = useState(false);
+  const [sig, setSig] = useState('');
+  const [error, setError] = useState('');
 
   const slots = useMemo(() => (date ? getDaySlots(listing.id, date) : []), [listing.id, date]);
 
@@ -73,10 +81,36 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
   }
 
   async function sign() {
+    if (!canSign) return;
+    if (!connected || !publicKey) {
+      setError('Connect your wallet to sign a contract.');
+      return;
+    }
     setSigning(true);
-    await new Promise((r) => setTimeout(r, 1200)); // mock on-chain escrow
-    setSigning(false);
-    setSigned(true);
+    setError('');
+    try {
+      const detail =
+        mode === 'slot'
+          ? `${date}:${slotIdx.join(',')}`
+          : `${rangeStart}_${rangeEnd ?? rangeStart}:${tier}`;
+      const memo = bookingMemo({ listingId: listing.id, mode, detail, total: cost.total });
+
+      let signature = '';
+      if (PAYMENTS_ENABLED) {
+        signature = await sendTreasuryTx({
+          payer: publicKey,
+          amountSol: cost.total,
+          memo,
+          sendTransaction,
+        });
+      }
+      setSig(signature);
+      setSigned(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Transaction failed');
+    } finally {
+      setSigning(false);
+    }
   }
 
   const isSelected = (d: string) => (mode === 'slot' ? d === date : d === rangeStart || d === rangeEnd);
@@ -187,14 +221,30 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
           <span>{cost.fee.toFixed(3)} SOL</span>
         </div>
         <div className={styles.totalRow}>
-          <span>Total escrow</span>
+          <span>Total payment</span>
           <span className={styles.totalVal}>{cost.total.toFixed(3)} SOL</span>
         </div>
       </div>
 
       <Button variant="cherry" full onClick={sign} disabled={!canSign || signing}>
-        {signed ? '✓ Contract Signed (Mock)' : signing ? 'Signing…' : 'Sign Contract'}
+        {signed
+          ? sig ? '✓ Contract Signed' : '✓ Contract Signed (Mock)'
+          : signing ? 'Signing…' : connected ? 'Sign Contract' : 'Connect Wallet to Sign'}
       </Button>
+
+      {error && <p className={styles.payNote} style={{ color: 'var(--cherry-bright)' }}>⚠ {error}</p>}
+      {signed && sig && (
+        <p className={styles.payNote}>
+          <a href={txUrl(sig)} target="_blank" rel="noreferrer"
+            style={{ color: 'var(--cherry-bright)', textDecoration: 'underline' }}>
+            View transaction on Solana Explorer ↗
+          </a>
+        </p>
+      )}
+      <p className={styles.payNote}>
+        Direct payment (MVP) — trustless on-chain escrow arrives with the program.
+      </p>
+
       <div className={styles.makeOffer}>
         <Button variant="ghost" full disabled={!canSign}>Save Draft</Button>
       </div>

--- a/components/contract/ContractBuilder.tsx
+++ b/components/contract/ContractBuilder.tsx
@@ -127,7 +127,9 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
     try {
       let memo: string;
       if (mode === 'slot') {
-        // Re-check for conflicts against the freshest data before paying.
+        // Re-check for conflicts against a FRESH chain scan (bypass the 60s
+        // cache) right before money moves.
+        clearBookingsCache();
         const fresh = await getListingBookings(listing.id);
         const taken = bookedSlotSet(fresh, date!);
         const clash = slotIdx.filter((i) => taken.has(i));

--- a/components/contract/ContractBuilder.tsx
+++ b/components/contract/ContractBuilder.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import type { Listing } from '@/lib/mockData';
-import { FILLER_TIERS } from '@/lib/constants';
-import { slotBookingCost, fillerCost, type CostBreakdown } from '@/lib/pricing';
-import { getDaySlots, getFillerCapacity } from '@/lib/availability';
-import { sendTreasuryTx } from '@/lib/transactions';
-import { bookingMemo } from '@/lib/bookings';
+import { FILLER_TIERS, SLOT_PRICE_USDC } from '@/lib/constants';
+import { slotCostUsdc, fillerCostUsdc, type UsdcCost } from '@/lib/pricing';
+import { getDaySlots, getDayStatus, getFillerCapacity } from '@/lib/availability';
+import {
+  getListingBookings,
+  clearBookingsCache,
+  bookedSlotSet,
+  slotBookingMemo,
+  fillerBookingMemo,
+  type OnChainBooking,
+} from '@/lib/bookings';
+import { sendUsdcTreasuryTx } from '@/lib/transactions';
+import { uploadToIPFS } from '@/lib/pinata';
 import { PAYMENTS_ENABLED } from '@/lib/config';
 import { txUrl } from '@/lib/explorer';
 import Button from '@/components/Button';
@@ -19,11 +27,21 @@ type Mode = 'slot' | 'filler';
 const daysBetween = (a: string, b: string) =>
   Math.round((Date.parse(b) - Date.parse(a)) / 86_400_000);
 
-const ZERO: CostBreakdown = { subtotal: 0, fee: 0, total: 0 };
+const ZERO: UsdcCost = { label: '—', totalUsdc: 0 };
 
 export default function ContractBuilder({ listing }: { listing: Listing }) {
   const { connected, publicKey, sendTransaction } = useWallet();
   const [mode, setMode] = useState<Mode>('slot');
+
+  // Real on-chain bookings for this listing (drives availability).
+  const [bookings, setBookings] = useState<OnChainBooking[]>([]);
+  useEffect(() => {
+    let active = true;
+    getListingBookings(listing.id)
+      .then((b) => { if (active) setBookings(b); })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [listing.id]);
 
   // Slot mode
   const [date, setDate] = useState<string | null>(null);
@@ -34,26 +52,30 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
   const [rangeEnd, setRangeEnd] = useState<string | null>(null);
   const [tier, setTier] = useState(FILLER_TIERS[1].id);
 
+  // Creative (the ad that actually gets served)
+  const [creativeCid, setCreativeCid] = useState('');
+  const [creativeName, setCreativeName] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
   const [signing, setSigning] = useState(false);
   const [signed, setSigned] = useState(false);
   const [sig, setSig] = useState('');
   const [error, setError] = useState('');
 
-  const slots = useMemo(() => (date ? getDaySlots(listing.id, date) : []), [listing.id, date]);
+  const slots = useMemo(
+    () => (date ? getDaySlots(listing.id, date, bookings) : []),
+    [listing.id, date, bookings]
+  );
 
   const fillerDays = rangeStart ? (rangeEnd ? daysBetween(rangeStart, rangeEnd) + 1 : 1) : 0;
-  const tierFactor = FILLER_TIERS.find((t) => t.id === tier)!.factor;
 
-  const cost: CostBreakdown =
+  const cost: UsdcCost =
     mode === 'slot'
-      ? slotIdx.length
-        ? slotBookingCost(listing.pricePerDay, slotIdx.length)
-        : ZERO
-      : fillerDays
-        ? fillerCost(listing.pricePerDay, fillerDays, tierFactor)
-        : ZERO;
+      ? slotIdx.length ? slotCostUsdc(slotIdx.length) : ZERO
+      : fillerDays ? fillerCostUsdc(fillerDays, tier) : ZERO;
 
-  const canSign = cost.total > 0;
+  const canSign = cost.totalUsdc > 0 && !!creativeCid;
 
   function pick(d: string) {
     setSigned(false);
@@ -80,6 +102,20 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
     setSigned(false);
   }
 
+  async function handleCreative(f: File) {
+    setUploading(true);
+    setError('');
+    try {
+      const cid = await uploadToIPFS(f);
+      setCreativeCid(cid);
+      setCreativeName(f.name);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Creative upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
   async function sign() {
     if (!canSign) return;
     if (!connected || !publicKey) {
@@ -89,20 +125,45 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
     setSigning(true);
     setError('');
     try {
-      const detail =
-        mode === 'slot'
-          ? `${date}:${slotIdx.join(',')}`
-          : `${rangeStart}_${rangeEnd ?? rangeStart}:${tier}`;
-      const memo = bookingMemo({ listingId: listing.id, mode, detail, total: cost.total });
+      let memo: string;
+      if (mode === 'slot') {
+        // Re-check for conflicts against the freshest data before paying.
+        const fresh = await getListingBookings(listing.id);
+        const taken = bookedSlotSet(fresh, date!);
+        const clash = slotIdx.filter((i) => taken.has(i));
+        if (clash.length > 0) {
+          setBookings(fresh);
+          setSlotIdx((prev) => prev.filter((i) => !taken.has(i)));
+          throw new Error('One or more selected slots were just booked — please reselect.');
+        }
+        memo = slotBookingMemo({
+          listingId: listing.id,
+          dateISO: date!,
+          slots: slotIdx,
+          creativeCid,
+          usdc: cost.totalUsdc,
+        });
+      } else {
+        memo = fillerBookingMemo({
+          listingId: listing.id,
+          startISO: rangeStart!,
+          endISO: rangeEnd ?? rangeStart!,
+          tier,
+          creativeCid,
+          usdc: cost.totalUsdc,
+        });
+      }
 
       let signature = '';
       if (PAYMENTS_ENABLED) {
-        signature = await sendTreasuryTx({
+        signature = await sendUsdcTreasuryTx({
           payer: publicKey,
-          amountSol: cost.total,
+          amountUsdc: cost.totalUsdc,
           memo,
           sendTransaction,
         });
+        clearBookingsCache();
+        getListingBookings(listing.id).then(setBookings).catch(() => {});
       }
       setSig(signature);
       setSigned(true);
@@ -121,7 +182,7 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
     <div className={styles.builder}>
       <div className={styles.kicker}>Contract Builder</div>
       <div className={styles.rate}>
-        {listing.pricePerDay.toFixed(2)} SOL<span> / day base</span>
+        ${SLOT_PRICE_USDC} USDC<span> / 15-min slot</span>
       </div>
 
       <div className={styles.modeToggle} role="tablist">
@@ -147,16 +208,22 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
 
       <p className={styles.modeHint}>
         {mode === 'slot'
-          ? 'Reserve specific time blocks, exclusively yours.'
-          : 'Run your ad in the gaps between booked slots, at a chosen frequency.'}
+          ? 'Reserve exclusive 15-minute windows (UTC), yours alone on the screen.'
+          : `Run your ad in the gaps between booked slots — from $${FILLER_TIERS[0].usdcPerDay} USDC/day.`}
       </p>
 
-      <AvailabilityCalendar listingId={listing.id} isSelected={isSelected} inRange={inRange} onPick={pick} />
+      <AvailabilityCalendar
+        listingId={listing.id}
+        isSelected={isSelected}
+        inRange={inRange}
+        onPick={pick}
+        dayStatus={(d) => getDayStatus(listing.id, d, bookings)}
+      />
 
       {mode === 'slot' && date && (
         <div className={styles.section}>
-          <div className={styles.sectionLabel}>Time blocks · {date}</div>
-          <div className={styles.slotList}>
+          <div className={styles.sectionLabel}>15-min windows (UTC) · {date}</div>
+          <div className={`${styles.slotList} ${styles.slotListScroll}`}>
             {slots.map((s) => {
               const selected = slotIdx.includes(s.index);
               const booked = s.status === 'booked';
@@ -169,7 +236,7 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
                   className={`${styles.slotRow} ${booked ? styles.slotBooked : ''} ${selected ? styles.slotSelected : ''}`}
                 >
                   <span>{s.label}</span>
-                  <span className={styles.slotMeta}>{booked ? `Booked · ${s.advertiser}` : selected ? 'Selected' : 'Available'}</span>
+                  <span className={styles.slotMeta}>{booked ? `Booked · ${s.advertiser}` : selected ? 'Selected' : `$${SLOT_PRICE_USDC}`}</span>
                 </button>
               );
             })}
@@ -194,18 +261,45 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
                 onClick={() => { setTier(t.id); setSigned(false); }}
                 className={`${styles.tier} ${tier === t.id ? styles.tierActive : ''}`}
               >
-                <span className={styles.tierLabel}>{t.label}</span>
+                <span className={styles.tierLabel}>{t.label} · ${t.usdcPerDay}/d</span>
                 <span className={styles.tierCadence}>{t.cadence}</span>
               </button>
             ))}
           </div>
           {rangeStart && (
             <p className={styles.fillerNote}>
-              ~{getFillerCapacity(listing.id, rangeStart).toLocaleString()} filler plays available on {rangeStart}.
+              ~{getFillerCapacity(listing.id, rangeStart, bookings).toLocaleString()} filler plays available on {rangeStart}.
             </p>
           )}
         </div>
       )}
+
+      {/* Creative upload — the ad that actually gets served on the screen */}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Your ad creative</div>
+        <button
+          type="button"
+          className={styles.creativeBtn}
+          onClick={() => fileRef.current?.click()}
+          disabled={uploading}
+        >
+          {uploading
+            ? 'Uploading to IPFS…'
+            : creativeCid
+              ? `✓ ${creativeName} · ${creativeCid.slice(0, 14)}…`
+              : '+ Upload creative (image, max 5MB)'}
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleCreative(f);
+          }}
+        />
+      </div>
 
       <div className={styles.soon}>
         <span>Coming soon</span> Location targeting · auto-optimized filler
@@ -213,23 +307,22 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
 
       <div className={styles.breakdown}>
         <div className={styles.row}>
-          <span>{mode === 'slot' ? `Slots (${slotIdx.length})` : `Filler · ${FILLER_TIERS.find((t) => t.id === tier)!.label}`}</span>
-          <span>{cost.subtotal.toFixed(3)} SOL</span>
-        </div>
-        <div className={styles.row}>
-          <span>Protocol fee (2.5%)</span>
-          <span>{cost.fee.toFixed(3)} SOL</span>
+          <span>{cost.totalUsdc > 0 ? cost.label : mode === 'slot' ? 'Select slots' : 'Select dates'}</span>
+          <span>{cost.totalUsdc.toFixed(2)} USDC</span>
         </div>
         <div className={styles.totalRow}>
           <span>Total payment</span>
-          <span className={styles.totalVal}>{cost.total.toFixed(3)} SOL</span>
+          <span className={styles.totalVal}>${cost.totalUsdc.toFixed(2)} USDC</span>
         </div>
       </div>
 
       <Button variant="cherry" full onClick={sign} disabled={!canSign || signing}>
         {signed
           ? sig ? '✓ Contract Signed' : '✓ Contract Signed (Mock)'
-          : signing ? 'Signing…' : connected ? 'Sign Contract' : 'Connect Wallet to Sign'}
+          : signing ? 'Signing…'
+            : !connected ? 'Connect Wallet to Sign'
+              : !creativeCid ? 'Upload a creative to sign'
+                : `Pay ${cost.totalUsdc.toFixed(2)} USDC & Sign`}
       </Button>
 
       {error && <p className={styles.payNote} style={{ color: 'var(--cherry-bright)' }}>⚠ {error}</p>}
@@ -239,10 +332,12 @@ export default function ContractBuilder({ listing }: { listing: Listing }) {
             style={{ color: 'var(--cherry-bright)', textDecoration: 'underline' }}>
             View transaction on Solana Explorer ↗
           </a>
+          {' '}· Your ad goes live in its booked window.
         </p>
       )}
       <p className={styles.payNote}>
-        Direct payment (MVP) — trustless on-chain escrow arrives with the program.
+        Paid in USDC to the Screen Sync treasury · booking + creative anchored on-chain ·
+        trustless escrow arrives with the program.
       </p>
 
       <div className={styles.makeOffer}>

--- a/docs/BACKEND-SETUP.md
+++ b/docs/BACKEND-SETUP.md
@@ -1,0 +1,116 @@
+# Backend setup — your manual inputs
+
+This is the **only** list of things you need to create/provide to take the dApp
+from mock mode to a live hybrid MVP on Solana **devnet**. It's intentionally short.
+
+> **Golden rule:** you will only ever paste **public** values + **one API key**.
+> You never give anyone (including this app, or me) a wallet **private key / seed
+> phrase**. If a step ever asks for a seed phrase, stop — it's wrong.
+
+The app runs fully in **mock mode with zero setup** (`npm run dev`). Each item below
+flips one piece from mock to real. Do them in any order.
+
+---
+
+## What runs without any setup (mock mode)
+
+- Browse the marketplace (demo seed listings), open listing details.
+- Connect a wallet (Phantom/Solflare).
+- Walk the full create-listing and booking flows (no real tx, no real upload).
+
+So you can click through everything first, then add the two items below to go live.
+
+---
+
+## 1. Treasury wallet address  (required for real payments + listings)
+
+This is the wallet that **receives** booking payments and acts as the on-chain
+"registry" we scan to discover listings. We only need its **public address**.
+
+1. Install **Phantom** (or Solflare) browser extension.
+2. Create a **new wallet** for the project (keep it separate from personal funds).
+   Save its recovery phrase somewhere safe — **never type it into this project.**
+3. In Phantom: **Settings → Developer Settings → Change Network → Devnet.**
+4. Copy the wallet's **public address** (the string starting like `7xK3...`).
+5. Paste it as:
+
+   ```
+   NEXT_PUBLIC_TREASURY_ADDRESS=<paste the public address>
+   ```
+
+> Public address = safe to share/commit-as-config. Private key/seed = never.
+
+---
+
+## 2. Pinata JWT  (required for real media + listing metadata on IPFS)
+
+This stores ad creatives and listing metadata on IPFS. The key stays **server-side**.
+
+1. Go to **https://pinata.cloud** → sign up (free tier is fine).
+2. **API Keys → New Key.**
+   - Enable **Admin** (simplest), or scoped: `pinFileToIPFS` + `pinJSONToIPFS`.
+3. Copy the **JWT** (the long token, *not* the API key/secret pair).
+4. Paste it as:
+
+   ```
+   PINATA_JWT=<paste the JWT>
+   ```
+
+> Secret. Never prefix with `NEXT_PUBLIC`. Never commit it.
+
+---
+
+## 3. (Optional) Dedicated RPC
+
+The default public devnet RPC works but is rate-limited and slow for reads.
+For smoother testing, get a free **devnet** RPC URL from Helius or QuickNode and set:
+
+```
+NEXT_PUBLIC_SOLANA_RPC_URL=<your devnet rpc url>
+```
+
+---
+
+## Where to put these values
+
+### Local testing (your machine)
+```bash
+cp .env.example .env.local      # then edit .env.local with the values above
+npm install
+npm run dev                     # http://localhost:3001
+```
+`.env.local` is git-ignored — it never gets committed.
+
+### Production (Netlify)
+Netlify **Site settings → Environment variables** → add the same names/values.
+- Public (safe): `NEXT_PUBLIC_TREASURY_ADDRESS`, `NEXT_PUBLIC_SOLANA_RPC_URL`, `NEXT_PUBLIC_IPFS_GATEWAY`
+- Secret (server-only): `PINATA_JWT`
+
+After adding/changing variables, trigger a redeploy.
+
+---
+
+## Quick test once live (devnet)
+
+1. Phantom on **Devnet**, get free SOL: run `solana airdrop 2 <your-address> --url devnet`
+   or use https://faucet.solana.com.
+2. Open the dApp → **Dashboard** shows your real SOL balance.
+3. **List Inventory** → upload an image → submit. Approve the tx in Phantom →
+   you get a **Solana Explorer** link, and the listing appears in the marketplace.
+4. Open a listing → **Contract Builder** → pick slot/dates → **Sign Contract** →
+   approve in Phantom → real SOL moves to the treasury, with an Explorer link.
+
+---
+
+## What's intentionally NOT in this MVP (Phase 2)
+
+These need a deployed Anchor program (which needs a dedicated **deploy wallet**
+and the Rust toolchain) and are deliberately deferred:
+
+- Trustless **escrow / refunds** (today payments are direct to the treasury — custodial).
+- On-chain **availability ledger** (slots/filler availability is still simulated).
+- **Proof-of-display** + the ad-serving SDK/oracle.
+- A fast read **indexer** (today we read listings straight from chain + IPFS, which is
+  lite and decentralized but slower at scale).
+
+See [`SMART-CONTRACTS.md`](./SMART-CONTRACTS.md) for the full Phase 2 plan.

--- a/docs/BACKEND-SETUP.md
+++ b/docs/BACKEND-SETUP.md
@@ -1,116 +1,108 @@
 # Backend setup — your manual inputs
 
-This is the **only** list of things you need to create/provide to take the dApp
-from mock mode to a live hybrid MVP on Solana **devnet**. It's intentionally short.
+Everything YOU must do by hand to take the self-contained MVP live on **devnet**.
+The MVP sells Screen Sync's **own** ad space (the house listing): flat **$20 USDC
+15-minute exclusive slots** + frequency filler ($5/$10/$20 per day), paid straight
+to the treasury, with the booked creative served onto the marketing website.
 
-> **Golden rule:** you will only ever paste **public** values + **one API key**.
-> You never give anyone (including this app, or me) a wallet **private key / seed
-> phrase**. If a step ever asks for a seed phrase, stop — it's wrong.
+> **Golden rule:** you only ever paste **public** values + **one API key**.
+> Never type a wallet **private key / seed phrase** into this project, an env
+> var, or a chat. If a step seems to ask for one, stop — it's wrong.
 
-The app runs fully in **mock mode with zero setup** (`npm run dev`). Each item below
-flips one piece from mock to real. Do them in any order.
-
----
-
-## What runs without any setup (mock mode)
-
-- Browse the marketplace (demo seed listings), open listing details.
-- Connect a wallet (Phantom/Solflare).
-- Walk the full create-listing and booking flows (no real tx, no real upload).
-
-So you can click through everything first, then add the two items below to go live.
+Zero-config still works: `npm run dev` runs the whole flow in mock mode.
 
 ---
 
-## 1. Treasury wallet address  (required for real payments + listings)
+## Checklist (everything manual, in order)
 
-This is the wallet that **receives** booking payments and acts as the on-chain
-"registry" we scan to discover listings. We only need its **public address**.
-
-1. Install **Phantom** (or Solflare) browser extension.
-2. Create a **new wallet** for the project (keep it separate from personal funds).
-   Save its recovery phrase somewhere safe — **never type it into this project.**
-3. In Phantom: **Settings → Developer Settings → Change Network → Devnet.**
-4. Copy the wallet's **public address** (the string starting like `7xK3...`).
-5. Paste it as:
-
-   ```
-   NEXT_PUBLIC_TREASURY_ADDRESS=<paste the public address>
-   ```
-
-> Public address = safe to share/commit-as-config. Private key/seed = never.
+| # | What | Where it goes |
+|---|------|----------------|
+| 1 | Treasury wallet → copy **public address** | `NEXT_PUBLIC_TREASURY_ADDRESS` |
+| 2 | Pinata account → copy **JWT** | `PINATA_JWT` (secret) |
+| 3 | Test USDC + SOL in your *advertiser* test wallet | (wallet only, no env) |
+| 4 | Set env in `.env.local` (local) and Netlify (prod) | see below |
+| 5 | Paste the ad-tag snippet into the marketing website | Hostinger editor |
+| 6 | *(Phase 2, later)* deploy wallet + `anchor deploy` | see `program/README.md` |
 
 ---
 
-## 2. Pinata JWT  (required for real media + listing metadata on IPFS)
+## 1. Treasury wallet (receives all USDC + acts as the on-chain registry)
 
-This stores ad creatives and listing metadata on IPFS. The key stays **server-side**.
-
-1. Go to **https://pinata.cloud** → sign up (free tier is fine).
-2. **API Keys → New Key.**
-   - Enable **Admin** (simplest), or scoped: `pinFileToIPFS` + `pinJSONToIPFS`.
-3. Copy the **JWT** (the long token, *not* the API key/secret pair).
-4. Paste it as:
-
+1. Install **Phantom**. Create a **new wallet dedicated to the project**
+   (separate from personal funds). Store the recovery phrase offline.
+2. Phantom → Settings → Developer Settings → **change network to Devnet**.
+3. Copy the wallet's **public address** →
    ```
-   PINATA_JWT=<paste the JWT>
+   NEXT_PUBLIC_TREASURY_ADDRESS=<public address>
    ```
+That's it — the treasury needs no funding; the first booking auto-creates its
+USDC token account (the advertiser pays that one-time ~0.002 SOL rent).
 
-> Secret. Never prefix with `NEXT_PUBLIC`. Never commit it.
+## 2. Pinata JWT (stores ad creatives + listing metadata on IPFS)
 
----
+1. https://pinata.cloud → sign up (free tier fine).
+2. API Keys → **New Key** → scope it to `pinFileToIPFS` + `pinJSONToIPFS`
+   (or Admin if simpler). Copy the **JWT**.
+3. ```
+   PINATA_JWT=<jwt>
+   ```
+   Secret — never `NEXT_PUBLIC`, never committed.
 
-## 3. (Optional) Dedicated RPC
+## 3. Test money (to play the advertiser and demo the loop)
 
-The default public devnet RPC works but is rate-limited and slow for reads.
-For smoother testing, get a free **devnet** RPC URL from Helius or QuickNode and set:
+Use a **second** Phantom wallet (or profile) as the "advertiser":
+- **Devnet SOL** (pays network fees): https://faucet.solana.com → paste address.
+- **Devnet USDC** (pays for slots): https://faucet.circle.com → select
+  **Solana Devnet** → paste address. This matches the app's default
+  `NEXT_PUBLIC_USDC_MINT` (Circle devnet USDC `4zMMC9...ncDU`).
 
+## 4. Where the env values go
+
+**Local:** `cp .env.example .env.local`, fill in — then `npm install && npm run dev`
+(http://localhost:3001).
+
+**Production (Netlify):** Site settings → Environment variables → add
+`NEXT_PUBLIC_TREASURY_ADDRESS`, `PINATA_JWT` (and optionally
+`NEXT_PUBLIC_SOLANA_RPC_URL` for a dedicated RPC). Redeploy.
+
+## 5. Put the ad space on the marketing website (Hostinger)
+
+Paste this **one snippet** where the banner should appear (replace the domain
+with your Netlify app URL):
+
+```html
+<!-- Screen Sync — on-chain ad space -->
+<script async src="https://YOUR-DAPP.netlify.app/tag.js"
+        data-listing="house_web" data-width="728" data-height="90"></script>
 ```
-NEXT_PUBLIC_SOLANA_RPC_URL=<your devnet rpc url>
-```
+
+What it does: every 60s it asks the dApp's `/api/ad` what's booked **right now**
+for the current 15-minute UTC window — exclusive slot first, then filler
+rotation (weighted Low 1× / Medium 2× / High 4×, house ad keeps a share), then
+the house "this space is for sale" ad. No cookies, no tracking.
+
+Tip for the sales pitch: link the banner's caption to
+`https://YOUR-DAPP.netlify.app/marketplace/house_web` — that's the live booking
+page for the very space the visitor is looking at.
+
+## 6. Phase 2 — program (deploy) wallet — later, not needed for the MVP
+
+When you're ready for trustless escrow (`program/`): create a **separate**
+deploy wallet (`solana-keygen new`), fund with devnet SOL, then follow
+`program/README.md` (`anchor build`, `keys sync`, `test`, `deploy`). Keep the
+deploy keypair offline; it's the program's upgrade authority.
 
 ---
 
-## Where to put these values
+## End-to-end demo script (what you'll show people)
 
-### Local testing (your machine)
-```bash
-cp .env.example .env.local      # then edit .env.local with the values above
-npm install
-npm run dev                     # http://localhost:3001
-```
-`.env.local` is git-ignored — it never gets committed.
+1. Marketing site shows the house ad in the banner (space for sale).
+2. Click through → dApp house listing → Contract Builder.
+3. As the "advertiser" wallet: pick a 15-min slot (UTC), **upload a creative**
+   (goes to IPFS), pay **$20 USDC** in Phantom.
+4. Explorer link proves payment + memo (listing, window, creative CID) on-chain.
+5. When the slot window arrives, **the website banner shows the paid creative**
+   (within ~60s). Filler bookings rotate in the gaps.
+6. USDC sits in the treasury wallet — check it in Phantom.
 
-### Production (Netlify)
-Netlify **Site settings → Environment variables** → add the same names/values.
-- Public (safe): `NEXT_PUBLIC_TREASURY_ADDRESS`, `NEXT_PUBLIC_SOLANA_RPC_URL`, `NEXT_PUBLIC_IPFS_GATEWAY`
-- Secret (server-only): `PINATA_JWT`
-
-After adding/changing variables, trigger a redeploy.
-
----
-
-## Quick test once live (devnet)
-
-1. Phantom on **Devnet**, get free SOL: run `solana airdrop 2 <your-address> --url devnet`
-   or use https://faucet.solana.com.
-2. Open the dApp → **Dashboard** shows your real SOL balance.
-3. **List Inventory** → upload an image → submit. Approve the tx in Phantom →
-   you get a **Solana Explorer** link, and the listing appears in the marketplace.
-4. Open a listing → **Contract Builder** → pick slot/dates → **Sign Contract** →
-   approve in Phantom → real SOL moves to the treasury, with an Explorer link.
-
----
-
-## What's intentionally NOT in this MVP (Phase 2)
-
-These need a deployed Anchor program (which needs a dedicated **deploy wallet**
-and the Rust toolchain) and are deliberately deferred:
-
-- Trustless **escrow / refunds** (today payments are direct to the treasury — custodial).
-- On-chain **availability ledger** (slots/filler availability is still simulated).
-- **Proof-of-display** + the ad-serving SDK/oracle.
-- A fast read **indexer** (today we read listings straight from chain + IPFS, which is
-  lite and decentralized but slower at scale).
-
-See [`SMART-CONTRACTS.md`](./SMART-CONTRACTS.md) for the full Phase 2 plan.
+That's decentralized P2P advertising, demonstrated on your own inventory.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,59 @@
+# Security notes
+
+Posture for the **hybrid MVP** (Solana devnet). Read alongside `BACKEND-SETUP.md`
+and `SMART-CONTRACTS.md` (Phase 2). This is a living doc — update it as the
+on-chain program and serving layer land.
+
+## Trust model (today)
+
+- **Payments are custodial.** Bookings/listing fees transfer SOL directly to the
+  treasury wallet. There is **no on-chain escrow or refund** yet — that requires
+  the Phase 2 Anchor program. The UI states this ("direct payment (MVP)").
+- **Source of truth = chain + IPFS.** Listings are IPFS metadata with the CID
+  anchored on-chain; discovery scans the treasury account's tx history. No DB.
+- **One server-side secret:** `PINATA_JWT`. Everything else is a public value.
+
+## What's handled
+
+| Area | Control |
+|------|---------|
+| Secret exposure | `PINATA_JWT` read only in `app/api/*` (nodejs runtime); never `NEXT_PUBLIC`, never bundled to the browser. |
+| Upload validation | Server-side re-validation of size + MIME + magic bytes in `/api/upload` (client checks are not trusted). |
+| Body-size DoS | `Content-Length` guard + `file.size` check **before** buffering in both API routes; only the first bytes are read for the magic check. |
+| Untrusted metadata | On-chain/IPFS listing fields are rendered through React (auto-escaped). `type` is validated against the known enum; results are capped (`MAX_RESULTS`). |
+| Ownership spoofing | A listing's `owner` is derived from the real tx **signer**, not from self-reported metadata. |
+| Error disclosure | API routes return generic messages; details are logged server-side only. |
+| Double-submit | Booking/listing buttons disable while a tx is in flight. |
+
+## Residual risks / known limitations (MVP)
+
+1. **Open pin endpoints (`/api/upload`, `/api/pin-json`).** No auth or rate limiting,
+   so a third party could consume your Pinata quota/bandwidth. Mitigated by size/type
+   caps. **Before mainnet:** add rate limiting (Netlify edge rate limits or an
+   external store — in-memory won't work on serverless), use **scoped** Pinata keys
+   (only `pinFileToIPFS` + `pinJSONToIPFS`), and consider gating writes behind a
+   wallet-signed message.
+2. **Custodial treasury.** Funds sent on booking are not escrowed; delivery/refund
+   is trust-based until the Anchor program ships (Phase 2).
+3. **Registry griefing.** Anyone can write listing-memo txs to the treasury (each
+   costs them the listing fee + network fee). `MAX_RESULTS` bounds UI impact; a real
+   indexer + on-chain `Listing` PDAs (Phase 2) remove the scan entirely.
+4. **Public RPC.** Default devnet RPC is rate-limited; use a dedicated RPC in prod.
+5. **Memo parsing.** Booking memos use delimiter-separated fields; the future
+   indexer should parse defensively (treat as untrusted, length-limit, prefer a
+   structured/length-prefixed encoding).
+
+## Operational
+
+- Never commit `.env.local`. Set production secrets in the Netlify dashboard.
+- The treasury wallet's **seed phrase/private key** is never needed by the app and
+  must never be shared or committed — only its public address is configured.
+- Rotate `PINATA_JWT` if it is ever exposed; revoke in the Pinata dashboard.
+
+## Phase 2 (on-chain program) — security checklist (to apply when built)
+
+- Validate all instruction inputs; enforce signer/PDA seeds and `owner` checks.
+- Escrow funds in a program PDA; release only on `settle` / refund on `cancel`.
+- Guard arithmetic (checked math) for fees/amounts; mirror `lib/pricing.ts`.
+- Gate privileged ix (`settle_booking`, `withdraw_fees`) to the config admin/oracle.
+- Independent review/audit before mainnet; run the Solana MCP `program_autofixer`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,12 +6,27 @@ on-chain program and serving layer land.
 
 ## Trust model (today)
 
-- **Payments are custodial.** Bookings/listing fees transfer SOL directly to the
-  treasury wallet. There is **no on-chain escrow or refund** yet — that requires
-  the Phase 2 Anchor program. The UI states this ("direct payment (MVP)").
-- **Source of truth = chain + IPFS.** Listings are IPFS metadata with the CID
-  anchored on-chain; discovery scans the treasury account's tx history. No DB.
+- **Payments are custodial.** Bookings pay **USDC** directly to the treasury
+  wallet (listing fees pay SOL). There is **no on-chain escrow or refund** yet —
+  that requires the Phase 2 Anchor program. Acceptable for the MVP because the
+  seller IS Screen Sync (you can't rug yourself); revisit before third-party
+  listings take real money.
+- **Source of truth = chain + IPFS.** Listings, bookings, and the served
+  creative all derive from treasury tx history + IPFS. No DB.
 - **One server-side secret:** `PINATA_JWT`. Everything else is a public value.
+
+### Serving-plane notes (`/api/ad` + `tag.js`)
+- `/api/ad` is public with `Access-Control-Allow-Origin: *` by design — it
+  returns only public on-chain data. RPC load is bounded by the 60s scan cache.
+- **Creative content is attacker-influenced**: anyone who pays $20 can put an
+  image on your website. The tag renders it as an `<img>` only (no HTML/JS
+  execution), but there is **no content moderation** — a paid booking could be
+  offensive imagery. MVP mitigations: it's devnet money today; before mainnet,
+  add a moderation gate (server checks creative before serving, an allow/deny
+  list keyed by CID, or human approval for first-time advertisers).
+- Slot conflicts are checked client-side before paying and enforced at serve
+  time by "first matching booking wins"; the Phase 2 program makes conflicts
+  impossible on-chain.
 
 ## What's handled
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,9 +24,15 @@ on-chain program and serving layer land.
   offensive imagery. MVP mitigations: it's devnet money today; before mainnet,
   add a moderation gate (server checks creative before serving, an allow/deny
   list keyed by CID, or human approval for first-time advertisers).
-- Slot conflicts are checked client-side before paying and enforced at serve
-  time by "first matching booking wins"; the Phase 2 program makes conflicts
-  impossible on-chain.
+- **Payment verification**: a booking memo only counts if the treasury's USDC
+  token-balance delta in that same tx covers the price implied by the memo's
+  terms (computed from OUR price list, never the memo's self-reported amount).
+  Listing memos likewise require the registry fee's lamport delta. Balance
+  deltas are consensus-verified and cannot be spoofed.
+- Slot conflicts: fresh chain scan immediately before payment, and at serve
+  time the FIRST payer wins (bookings ordered oldest-first). A loser in the
+  rare same-minute race needs a manual refund until the Phase 2 program makes
+  conflicts impossible on-chain.
 
 ## What's handled
 

--- a/docs/SMART-CONTRACTS.md
+++ b/docs/SMART-CONTRACTS.md
@@ -161,7 +161,7 @@ Round all UI numbers; on-chain is integer lamports — convert with `lib/format.
 
 ## 9. Implementation plan (phased — aligns with the hybrid → on-chain roadmap)
 
-- **Phase 2a — Anchor core (devnet):** scaffold `screen_sync_marketplace` (Anchor); `initialize_config`, `register_listing`, `book_slot`, `book_filler`, `settle_booking`, `cancel_booking`; SOL escrow; treasury fee. Tests.
+- **Phase 2a — Anchor core (devnet):** ✅ **scaffolded in [`program/`](../program/)** — `initialize_config`, `update_config`, `register_listing`, `update_listing`, `book_slot`, `book_filler`, `settle_booking`, `cancel_booking`; SOL escrow in a per-booking PDA; 2.5% treasury fee; integer-lamport pricing mirroring `lib/pricing.ts`. **Not yet built/deployed** (needs the Anchor/Solana toolchain + deploy wallet). See [`program/README.md`](../program/README.md).
 - **Phase 2b — Metaplex assets:** create Listings + Creatives Core collections (CLI); mint listing NFT on register, contract NFT on book (Umi in `lib/solana.ts`). Pinata live in `lib/pinata.ts`.
 - **Phase 2c — wire dApp:** swap `lib/solana.ts`, `lib/availability.ts`, `lib/pinata.ts` internals to the program + DAS, keeping return shapes. Wallet already integrated (`@solana/wallet-adapter`, Phantom/Solflare).
 - **Phase 3 — serving + proof-of-display:** build `tag.js` ad tag + serving/oracle service; Bubblegum cNFT impression receipts; `record_delivery`; dispute resolution against receipts.

--- a/lib/availability.ts
+++ b/lib/availability.ts
@@ -1,17 +1,17 @@
-// Mock availability + time-slot model for the Contract Builder.
+// Availability — 15-minute UTC slots (96/day), derived from REAL on-chain
+// bookings for the house listing (and any on-chain listing). Demo seed listings
+// keep a deterministic mock overlay so the marketplace looks alive.
 //
-// Phase 1: deterministic mock data (seeded per listing+date) so the calendar and
-// slot list look consistent across renders. Later this is replaced by on-chain
-// booking reads, and location filters + an optimizer/LLM will suggest filler placements.
-import { BLOCKS_PER_DAY } from './constants';
-
-const HOURS_PER_BLOCK = 24 / BLOCKS_PER_DAY;
+// All times are UTC: the dApp, /api/ad, and the website tag share slot windows.
+import { SLOTS_PER_DAY, SLOT_MINUTES } from './constants';
+import { HOUSE_LISTING_ID, LISTINGS } from './mockData';
+import { type OnChainBooking, bookedSlotSet } from './bookings';
 
 export interface TimeSlot {
   index: number;
-  start: string; // "09:00"
-  end: string; // "12:00"
-  label: string; // "09:00 – 12:00"
+  start: string; // "09:00" (UTC)
+  end: string; // "09:15" (UTC)
+  label: string; // "09:00 – 09:15"
   status: 'available' | 'booked';
   advertiser?: string;
 }
@@ -30,35 +30,70 @@ function seed(str: string): number {
   return (h >>> 0) / 4294967296;
 }
 
-const hhmm = (h: number) => `${String(h % 24).padStart(2, '0')}:00`;
+const hhmm = (mins: number) =>
+  `${String(Math.floor(mins / 60) % 24).padStart(2, '0')}:${String(mins % 60).padStart(2, '0')}`;
 
-/** The time-block schedule for a given listing + date, with which blocks are taken. */
-export function getDaySlots(listingId: string, dateISO: string): TimeSlot[] {
-  return Array.from({ length: BLOCKS_PER_DAY }, (_, i) => {
-    const startH = i * HOURS_PER_BLOCK;
-    const booked = seed(`${listingId}|${dateISO}|${i}`) < 0.45;
-    const adv = MOCK_ADVERTISERS[Math.floor(seed(`${listingId}|${dateISO}|${i}|a`) * MOCK_ADVERTISERS.length)];
+/** Demo seed listings get mock occupancy; the house listing is always real-only. */
+export const isDemoListing = (listingId: string): boolean =>
+  listingId !== HOUSE_LISTING_ID && LISTINGS.some((l) => l.id === listingId);
+
+function mockBooked(listingId: string, dateISO: string): Set<number> {
+  const set = new Set<number>();
+  if (!isDemoListing(listingId)) return set;
+  for (let i = 0; i < SLOTS_PER_DAY; i++) {
+    if (seed(`${listingId}|${dateISO}|${i}`) < 0.35) set.add(i);
+  }
+  return set;
+}
+
+/**
+ * The 96-slot schedule for (listing, UTC date). `bookings` are the listing's
+ * real on-chain bookings (pass [] when none / mock mode).
+ */
+export function getDaySlots(
+  listingId: string,
+  dateISO: string,
+  bookings: OnChainBooking[] = []
+): TimeSlot[] {
+  const real = bookedSlotSet(bookings, dateISO);
+  const mock = mockBooked(listingId, dateISO);
+  return Array.from({ length: SLOTS_PER_DAY }, (_, i) => {
+    const startM = i * SLOT_MINUTES;
+    const isReal = real.has(i);
+    const booked = isReal || mock.has(i);
+    const adv = isReal
+      ? 'On-chain booking'
+      : MOCK_ADVERTISERS[Math.floor(seed(`${listingId}|${dateISO}|${i}|a`) * MOCK_ADVERTISERS.length)];
     return {
       index: i,
-      start: hhmm(startH),
-      end: hhmm(startH + HOURS_PER_BLOCK),
-      label: `${hhmm(startH)} – ${hhmm(startH + HOURS_PER_BLOCK)}`,
+      start: hhmm(startM),
+      end: hhmm(startM + SLOT_MINUTES),
+      label: `${hhmm(startM)} – ${hhmm(startM + SLOT_MINUTES)}`,
       status: booked ? 'booked' : 'available',
       advertiser: booked ? adv : undefined,
     };
   });
 }
 
-/** Day-level rollup used to color the calendar. */
-export function getDayStatus(listingId: string, dateISO: string): DayStatus {
-  const booked = getDaySlots(listingId, dateISO).filter((s) => s.status === 'booked').length;
+/** Day-level rollup used to colour the calendar. */
+export function getDayStatus(
+  listingId: string,
+  dateISO: string,
+  bookings: OnChainBooking[] = []
+): DayStatus {
+  const booked = bookedSlotSet(bookings, dateISO).size + mockBooked(listingId, dateISO).size;
   if (booked === 0) return 'open';
-  if (booked >= BLOCKS_PER_DAY) return 'full';
+  if (booked >= SLOTS_PER_DAY) return 'full';
   return 'partial';
 }
 
-/** Estimated filler plays available in the gaps between premium ads (mock). */
-export function getFillerCapacity(listingId: string, dateISO: string): number {
-  const open = getDaySlots(listingId, dateISO).filter((s) => s.status === 'available').length;
-  return open * 60; // ~60 filler plays per open block
+/** Estimated filler plays available in the gaps between booked slots. */
+export function getFillerCapacity(
+  listingId: string,
+  dateISO: string,
+  bookings: OnChainBooking[] = []
+): number {
+  const open =
+    SLOTS_PER_DAY - bookedSlotSet(bookings, dateISO).size - mockBooked(listingId, dateISO).size;
+  return Math.max(open, 0) * 4; // ~4 filler plays per open 15-min slot
 }

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,0 +1,12 @@
+// Booking memo format. Bookings are real SOL payments to the treasury carrying
+// this memo, so they're auditable on-chain and indexable later (no DB needed).
+const BOOKING_MEMO_PREFIX = 'ss:book:v1:';
+
+export function bookingMemo(args: {
+  listingId: string;
+  mode: 'slot' | 'filler';
+  detail: string; // slot: "<date>:<slotIdxs>"  filler: "<start>_<end>:<tier>"
+  total: number;
+}): string {
+  return `${BOOKING_MEMO_PREFIX}${args.listingId}|${args.mode}|${args.detail}|${args.total.toFixed(4)}`;
+}

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -10,7 +10,8 @@
 // real availability, and /api/ad reads them to decide which creative to serve.
 // All slot windows are UTC so the dApp, server, and website agree on timing.
 import type { ParsedTransactionWithMeta } from '@solana/web3.js';
-import { SLOTS_PER_DAY, FILLER_TIERS, type FillerTier } from './constants';
+import { SLOTS_PER_DAY, SLOT_PRICE_USDC, FILLER_TIERS, type FillerTier } from './constants';
+import { USDC_MINT, USDC_DECIMALS } from './config';
 import { getConnection, getTreasury } from './connection';
 
 const BOOKING_MEMO_PREFIX = 'ss:book:v2:';
@@ -109,6 +110,30 @@ function firstSigner(tx: ParsedTransactionWithMeta): string {
   return signer ? signer.pubkey.toString() : '';
 }
 
+/** Price (USDC) the parsed terms actually cost — computed from OUR price list,
+ *  never from the memo's self-reported amount. */
+function expectedPriceUsdc(b: Omit<OnChainBooking, 'advertiser' | 'signature'>): number {
+  if (b.mode === 'slot') return b.slots!.length * SLOT_PRICE_USDC;
+  const tier = FILLER_TIERS.find((t) => t.id === b.tier)!;
+  const days =
+    Math.round((Date.parse(b.endISO!) - Date.parse(b.startISO!)) / 86_400_000) + 1;
+  return tier.usdcPerDay * days;
+}
+
+/** How much USDC the treasury actually RECEIVED in this tx (post - pre balance
+ *  across the treasury's USDC token accounts). Memos are attacker-controlled;
+ *  this delta is consensus-verified and cannot be faked. */
+function usdcReceived(tx: ParsedTransactionWithMeta, treasury: string): number {
+  if (!tx.meta) return 0;
+  type TokenBalances = NonNullable<ParsedTransactionWithMeta['meta']>['preTokenBalances'];
+  const sum = (list: TokenBalances) =>
+    (list ?? [])
+      .filter((b) => b.owner === treasury && b.mint === USDC_MINT)
+      .reduce((s, b) => s + Number(b.uiTokenAmount.amount), 0);
+  const delta = sum(tx.meta.postTokenBalances) - sum(tx.meta.preTokenBalances);
+  return delta / 10 ** USDC_DECIMALS;
+}
+
 let cache: { at: number; bookings: OnChainBooking[] } | null = null;
 
 /** Drop the scan cache (call after making a booking so the UI shows it). */
@@ -132,6 +157,7 @@ export async function getTreasuryBookings(): Promise<OnChainBooking[]> {
       sigs.map((s) => s.signature),
       { maxSupportedTransactionVersion: 0, commitment: 'confirmed' }
     );
+    const treasuryStr = treasury.toBase58();
     const bookings: OnChainBooking[] = [];
     for (let i = 0; i < txs.length; i++) {
       const tx = txs[i];
@@ -140,8 +166,15 @@ export async function getTreasuryBookings(): Promise<OnChainBooking[]> {
       if (!memo) continue;
       const parsed = parseBookingMemo(memo);
       if (!parsed) continue;
+      // CRITICAL: a booking only counts if the treasury actually received the
+      // full price implied by its terms. Small epsilon absorbs float rounding.
+      const paid = usdcReceived(tx, treasuryStr);
+      if (paid + 1e-6 < expectedPriceUsdc(parsed)) continue;
       bookings.push({ ...parsed, advertiser: firstSigner(tx), signature: sigs[i].signature });
     }
+    // Oldest first: if two txs ever claim the same slot, the FIRST payer wins
+    // (consumers use find(), so earlier bookings take priority).
+    bookings.reverse();
     cache = { at: Date.now(), bookings };
     return bookings;
   } catch (e) {

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,12 +1,173 @@
-// Booking memo format. Bookings are real SOL payments to the treasury carrying
-// this memo, so they're auditable on-chain and indexable later (no DB needed).
-const BOOKING_MEMO_PREFIX = 'ss:book:v1:';
+// Bookings — database-free, USDC MVP.
+//
+// A booking is a real USDC payment to the treasury carrying a v2 memo:
+//
+//   ss:book:v2:<listingId>|<mode>|<detail>|<creativeCid>|<usdc>
+//     slot   detail: <dateISO>:<slotIdx,slotIdx,...>   (15-min UTC slots, 0-95)
+//     filler detail: <startISO>_<endISO>:<tier>        (low | medium | high)
+//
+// The chain is the booking database: the Contract Builder reads these to show
+// real availability, and /api/ad reads them to decide which creative to serve.
+// All slot windows are UTC so the dApp, server, and website agree on timing.
+import type { ParsedTransactionWithMeta } from '@solana/web3.js';
+import { SLOTS_PER_DAY, FILLER_TIERS, type FillerTier } from './constants';
+import { getConnection, getTreasury } from './connection';
 
-export function bookingMemo(args: {
+const BOOKING_MEMO_PREFIX = 'ss:book:v2:';
+const SCAN_LIMIT = 500;
+const CACHE_TTL_MS = 60_000;
+
+export interface OnChainBooking {
   listingId: string;
   mode: 'slot' | 'filler';
-  detail: string; // slot: "<date>:<slotIdxs>"  filler: "<start>_<end>:<tier>"
-  total: number;
+  /** slot mode */
+  dateISO?: string;
+  slots?: number[];
+  /** filler mode */
+  startISO?: string;
+  endISO?: string;
+  tier?: FillerTier['id'];
+  creativeCid: string;
+  usdc: number;
+  advertiser: string;
+  signature: string;
+}
+
+// ---- Memo build -------------------------------------------------------------
+
+export function slotBookingMemo(args: {
+  listingId: string;
+  dateISO: string;
+  slots: number[];
+  creativeCid: string;
+  usdc: number;
 }): string {
-  return `${BOOKING_MEMO_PREFIX}${args.listingId}|${args.mode}|${args.detail}|${args.total.toFixed(4)}`;
+  const detail = `${args.dateISO}:${[...args.slots].sort((a, b) => a - b).join(',')}`;
+  return `${BOOKING_MEMO_PREFIX}${args.listingId}|slot|${detail}|${args.creativeCid}|${args.usdc}`;
+}
+
+export function fillerBookingMemo(args: {
+  listingId: string;
+  startISO: string;
+  endISO: string;
+  tier: FillerTier['id'];
+  creativeCid: string;
+  usdc: number;
+}): string {
+  const detail = `${args.startISO}_${args.endISO}:${args.tier}`;
+  return `${BOOKING_MEMO_PREFIX}${args.listingId}|filler|${detail}|${args.creativeCid}|${args.usdc}`;
+}
+
+// ---- Memo parse (defensive — memos are attacker-controlled) ------------------
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const isTier = (t: string): t is FillerTier['id'] => FILLER_TIERS.some((x) => x.id === t);
+
+export function parseBookingMemo(memo: string): Omit<OnChainBooking, 'advertiser' | 'signature'> | null {
+  if (!memo.startsWith(BOOKING_MEMO_PREFIX) || memo.length > 512) return null;
+  const parts = memo.slice(BOOKING_MEMO_PREFIX.length).split('|');
+  if (parts.length !== 5) return null;
+  const [listingId, mode, detail, creativeCid, usdcStr] = parts;
+  const usdc = Number(usdcStr);
+  if (!listingId || !creativeCid || !Number.isFinite(usdc) || usdc < 0) return null;
+
+  if (mode === 'slot') {
+    const [dateISO, slotsStr] = detail.split(':');
+    if (!DATE_RE.test(dateISO) || !slotsStr) return null;
+    const slots = slotsStr
+      .split(',')
+      .map((s) => Number(s))
+      .filter((n) => Number.isInteger(n) && n >= 0 && n < SLOTS_PER_DAY);
+    if (slots.length === 0 || slots.length > SLOTS_PER_DAY) return null;
+    return { listingId, mode, dateISO, slots, creativeCid, usdc };
+  }
+
+  if (mode === 'filler') {
+    const [range, tier] = detail.split(':');
+    const [startISO, endISO] = (range ?? '').split('_');
+    if (!DATE_RE.test(startISO) || !DATE_RE.test(endISO) || !isTier(tier ?? '')) return null;
+    if (endISO < startISO) return null;
+    return { listingId, mode, startISO, endISO, tier: tier as FillerTier['id'], creativeCid, usdc };
+  }
+
+  return null;
+}
+
+// ---- Chain reads (cached) ----------------------------------------------------
+
+function extractMemo(tx: ParsedTransactionWithMeta): string | null {
+  for (const ix of tx.transaction.message.instructions) {
+    if ('program' in ix && ix.program === 'spl-memo' && typeof ix.parsed === 'string') {
+      return ix.parsed;
+    }
+  }
+  return null;
+}
+
+function firstSigner(tx: ParsedTransactionWithMeta): string {
+  const signer = tx.transaction.message.accountKeys.find((k) => k.signer);
+  return signer ? signer.pubkey.toString() : '';
+}
+
+let cache: { at: number; bookings: OnChainBooking[] } | null = null;
+
+/** Drop the scan cache (call after making a booking so the UI shows it). */
+export function clearBookingsCache(): void {
+  cache = null;
+}
+
+/** All bookings recorded against the treasury (cached 60s). Empty in mock mode. */
+export async function getTreasuryBookings(): Promise<OnChainBooking[]> {
+  const treasury = getTreasury();
+  if (!treasury) return [];
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.bookings;
+  try {
+    const conn = getConnection();
+    const sigs = await conn.getSignaturesForAddress(treasury, { limit: SCAN_LIMIT });
+    if (sigs.length === 0) {
+      cache = { at: Date.now(), bookings: [] };
+      return [];
+    }
+    const txs = await conn.getParsedTransactions(
+      sigs.map((s) => s.signature),
+      { maxSupportedTransactionVersion: 0, commitment: 'confirmed' }
+    );
+    const bookings: OnChainBooking[] = [];
+    for (let i = 0; i < txs.length; i++) {
+      const tx = txs[i];
+      if (!tx || tx.meta?.err) continue;
+      const memo = extractMemo(tx);
+      if (!memo) continue;
+      const parsed = parseBookingMemo(memo);
+      if (!parsed) continue;
+      bookings.push({ ...parsed, advertiser: firstSigner(tx), signature: sigs[i].signature });
+    }
+    cache = { at: Date.now(), bookings };
+    return bookings;
+  } catch (e) {
+    console.error('[Screen Sync] getTreasuryBookings failed', e);
+    return cache?.bookings ?? [];
+  }
+}
+
+/** Bookings for one listing. */
+export async function getListingBookings(listingId: string): Promise<OnChainBooking[]> {
+  const all = await getTreasuryBookings();
+  return all.filter((b) => b.listingId === listingId);
+}
+
+/** Slot indexes already booked for (listing, UTC date). */
+export function bookedSlotSet(bookings: OnChainBooking[], dateISO: string): Set<number> {
+  const set = new Set<number>();
+  for (const b of bookings) {
+    if (b.mode === 'slot' && b.dateISO === dateISO) for (const s of b.slots!) set.add(s);
+  }
+  return set;
+}
+
+/** Filler bookings active on a UTC date. */
+export function activeFillers(bookings: OnChainBooking[], dateISO: string): OnChainBooking[] {
+  return bookings.filter(
+    (b) => b.mode === 'filler' && b.startISO! <= dateISO && dateISO <= b.endISO!
+  );
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,32 @@
+// Centralized runtime configuration + feature flags.
+//
+// Only CLIENT-SAFE (public) values live here. Server-only secrets
+// (PINATA_JWT, SUPABASE_SERVICE_ROLE_KEY) are read directly inside their
+// server modules so they are never bundled into the browser.
+//
+// Every integration is feature-flagged: when its env vars are absent the
+// app falls back to mock behaviour, so it runs locally before any keys exist.
+
+/** Solana JSON-RPC endpoint. Defaults to the public devnet. */
+export const SOLANA_RPC_URL =
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+
+/** Cluster label, used for Explorer links and UI copy. */
+export const SOLANA_CLUSTER = process.env.NEXT_PUBLIC_SOLANA_CLUSTER || 'devnet';
+
+/** Public IPFS gateway for reads. */
+export const IPFS_GATEWAY =
+  process.env.NEXT_PUBLIC_IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs';
+
+/** Treasury wallet that receives booking/listing payments (PUBLIC address). */
+export const TREASURY_ADDRESS = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || '';
+
+/** Supabase project URL + anon (public) key for client-side reads. */
+export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+export const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+/** Real SOL payments go live once a treasury address is configured. */
+export const PAYMENTS_ENABLED = TREASURY_ADDRESS.length > 0;
+
+/** Client-side Supabase reads go live once URL + anon key are configured. */
+export const SUPABASE_ENABLED = SUPABASE_URL.length > 0 && SUPABASE_ANON_KEY.length > 0;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,8 +1,8 @@
 // Centralized runtime configuration + feature flags.
 //
-// Only CLIENT-SAFE (public) values live here. Server-only secrets
-// (PINATA_JWT, SUPABASE_SERVICE_ROLE_KEY) are read directly inside their
-// server modules so they are never bundled into the browser.
+// Only CLIENT-SAFE (public) values live here. The one server-only secret
+// (PINATA_JWT) is read directly inside the API routes so it is never bundled
+// into the browser.
 //
 // Every integration is feature-flagged: when its env vars are absent the
 // app falls back to mock behaviour, so it runs locally before any keys exist.
@@ -21,12 +21,5 @@ export const IPFS_GATEWAY =
 /** Treasury wallet that receives booking/listing payments (PUBLIC address). */
 export const TREASURY_ADDRESS = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || '';
 
-/** Supabase project URL + anon (public) key for client-side reads. */
-export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-export const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-
 /** Real SOL payments go live once a treasury address is configured. */
 export const PAYMENTS_ENABLED = TREASURY_ADDRESS.length > 0;
-
-/** Client-side Supabase reads go live once URL + anon key are configured. */
-export const SUPABASE_ENABLED = SUPABASE_URL.length > 0 && SUPABASE_ANON_KEY.length > 0;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -21,5 +21,16 @@ export const IPFS_GATEWAY =
 /** Treasury wallet that receives booking/listing payments (PUBLIC address). */
 export const TREASURY_ADDRESS = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || '';
 
-/** Real SOL payments go live once a treasury address is configured. */
+/**
+ * USDC mint used for booking payments. Defaults to Circle's official DEVNET
+ * USDC mint (get test USDC at https://faucet.circle.com). For mainnet set
+ * NEXT_PUBLIC_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.
+ */
+export const USDC_MINT =
+  process.env.NEXT_PUBLIC_USDC_MINT || '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+
+/** USDC has 6 decimal places. */
+export const USDC_DECIMALS = 6;
+
+/** Real payments go live once a treasury address is configured. */
 export const PAYMENTS_ENABLED = TREASURY_ADDRESS.length > 0;

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -1,0 +1,21 @@
+// Shared Solana RPC connection + treasury helper. Safe to import client or server.
+import { Connection, PublicKey } from '@solana/web3.js';
+import { SOLANA_RPC_URL, TREASURY_ADDRESS } from './config';
+
+let conn: Connection | null = null;
+
+export function getConnection(): Connection {
+  if (!conn) conn = new Connection(SOLANA_RPC_URL, 'confirmed');
+  return conn;
+}
+
+/** Parsed treasury pubkey (payments + on-chain listing registry), or null in mock mode. */
+export function getTreasury(): PublicKey | null {
+  if (!TREASURY_ADDRESS) return null;
+  try {
+    return new PublicKey(TREASURY_ADDRESS);
+  } catch {
+    console.error('[Screen Sync] Invalid NEXT_PUBLIC_TREASURY_ADDRESS');
+    return null;
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,6 +6,14 @@ export const LAMPORTS_PER_SOL = BigInt(1_000_000_000);
 /** Platform fee in basis points (2.5%). One flat protocol fee, no layered take-rates. */
 export const PLATFORM_FEE_BPS = 250;
 
+/**
+ * Small on-chain fee (SOL) paid when registering a listing. Doubles as anti-spam
+ * and as the transfer that anchors the listing to the treasury "registry" account
+ * so it's discoverable by scanning treasury tx history (no database needed).
+ * Set to 0 to make listing free (registration still anchors via the memo tx).
+ */
+export const LISTING_FEE_SOL = 0.001;
+
 /** Max upload size for ad creatives (5 MB). */
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -54,24 +54,40 @@ export const FILE_SIGNATURES: Record<string, number[]> = {
   'video/webm': [0x1a, 0x45, 0xdf, 0xa3],
 };
 
-// ---- Contract Builder ----
+// ---- Contract Builder — MVP pricing (USDC) ----
+//
+// The self-contained MVP sells Screen Sync's OWN ad space: exclusive 15-minute
+// slots at a flat USDC price, plus frequency-based filler. All slot windows are
+// defined in UTC so the dApp, the ad server, and the website agree on timing.
 
-/** A day is split into time blocks advertisers can reserve exclusively (3-hour blocks). */
-export const BLOCKS_PER_DAY = 8;
+/** Exclusive slot length (minutes). */
+export const SLOT_MINUTES = 15;
 
-/** An exclusive premium slot costs more than the per-day average rate. */
-export const SLOT_PREMIUM = 1.5;
+/** 15-minute slots per day (24h × 4). */
+export const SLOTS_PER_DAY = (24 * 60) / SLOT_MINUTES; // 96
+
+/** Flat price of one exclusive 15-minute slot (USDC). */
+export const SLOT_PRICE_USDC = 20;
 
 export interface FillerTier {
   id: 'low' | 'medium' | 'high';
   label: string;
-  factor: number; // fraction of pricePerDay charged per day
+  usdcPerDay: number; // flat USDC per day at this frequency
+  weight: number; // relative rotation share in the serving loop
   cadence: string; // human-readable rotation frequency
 }
 
-/** Filler runs your ad in the gaps between premium slot ads, at a chosen frequency. */
+/** Filler runs your ad in the gaps between booked slots, at a chosen frequency. */
 export const FILLER_TIERS: FillerTier[] = [
-  { id: 'low', label: 'Low', factor: 0.25, cadence: '~1 in 6 rotations' },
-  { id: 'medium', label: 'Medium', factor: 0.5, cadence: '~1 in 3 rotations' },
-  { id: 'high', label: 'High', factor: 1.0, cadence: '~every other rotation' },
+  { id: 'low', label: 'Low', usdcPerDay: 5, weight: 1, cadence: '~1 in 6 rotations' },
+  { id: 'medium', label: 'Medium', usdcPerDay: 10, weight: 2, cadence: '~1 in 3 rotations' },
+  { id: 'high', label: 'High', usdcPerDay: 20, weight: 4, cadence: '~every other rotation' },
 ];
+
+// ---- Legacy / Phase 2 program constants (SOL-denominated escrow model) ----
+
+/** Phase 2 Anchor program: blocks per day in the on-chain slot bitmap. */
+export const BLOCKS_PER_DAY = 8;
+
+/** Phase 2 Anchor program: exclusive-slot premium over the per-day average rate. */
+export const SLOT_PREMIUM = 1.5;

--- a/lib/explorer.ts
+++ b/lib/explorer.ts
@@ -1,0 +1,12 @@
+// Solana Explorer link helpers (cluster-aware).
+import { SOLANA_CLUSTER } from './config';
+
+const suffix = SOLANA_CLUSTER === 'mainnet-beta' ? '' : `?cluster=${SOLANA_CLUSTER}`;
+
+/** Explorer URL for a transaction signature. */
+export const txUrl = (signature: string): string =>
+  `https://explorer.solana.com/tx/${signature}${suffix}`;
+
+/** Explorer URL for an account/address. */
+export const addressUrl = (address: string): string =>
+  `https://explorer.solana.com/address/${address}${suffix}`;

--- a/lib/listings.ts
+++ b/lib/listings.ts
@@ -1,0 +1,150 @@
+// Listings data layer — database-free.
+//
+// Source of truth = chain + IPFS:
+//   * Listing metadata (title, price, creative CID, ...) is pinned to IPFS.
+//   * A registration tx anchors the metadata CID on-chain via a memo, with a
+//     transfer to the treasury so the listing is discoverable by scanning the
+//     treasury account's tx history.
+//   * Reading = scan treasury signatures -> parse memos -> resolve IPFS metadata.
+//
+// The demo seed catalog (lib/mockData LISTINGS) is always appended so the
+// marketplace is never empty. Everything degrades to seed-only in mock mode.
+import type { ParsedTransactionWithMeta } from '@solana/web3.js';
+import type { Listing, ListingType, PublisherType } from './mockData';
+import { LISTINGS } from './mockData';
+import { getConnection, getTreasury } from './connection';
+import { ipfsUrl } from './pinata';
+
+const LISTING_MEMO_PREFIX = 'ss:list:v1:';
+const SCAN_LIMIT = 200;
+
+/** Shape pinned to IPFS for each listing. */
+export interface ListingMetadata {
+  v: 1;
+  type: ListingType;
+  title: string;
+  location: string;
+  pricePerDay: number;
+  description: string;
+  tags: string[];
+  audience: string;
+  impressionsPerDay: number;
+  publisherType: PublisherType;
+  mediaCid: string;
+  owner: string;
+  createdAt: number;
+}
+
+/** Pin listing metadata JSON to IPFS, returning its CID. */
+export async function pinListingMetadata(meta: ListingMetadata): Promise<string> {
+  const res = await fetch('/api/pin-json', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(meta),
+  });
+  const data = (await res.json().catch(() => ({}))) as { cid?: string; error?: string };
+  if (!res.ok || !data.cid) throw new Error(data.error || 'Failed to pin metadata');
+  return data.cid;
+}
+
+/** Build the memo that anchors a listing's metadata CID on-chain. */
+export const listingMemo = (metadataCid: string): string => `${LISTING_MEMO_PREFIX}${metadataCid}`;
+
+// ---- Reads ---------------------------------------------------------------
+
+function extractMemo(tx: ParsedTransactionWithMeta): string | null {
+  for (const ix of tx.transaction.message.instructions) {
+    if ('program' in ix && ix.program === 'spl-memo' && typeof ix.parsed === 'string') {
+      return ix.parsed;
+    }
+  }
+  return null;
+}
+
+function firstSigner(tx: ParsedTransactionWithMeta): string {
+  const signer = tx.transaction.message.accountKeys.find((k) => k.signer);
+  return signer ? signer.pubkey.toString() : '';
+}
+
+async function fetchMetadata(cid: string): Promise<ListingMetadata | null> {
+  try {
+    const res = await fetch(ipfsUrl(cid));
+    if (!res.ok) return null;
+    return (await res.json()) as ListingMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function metaToListing(cid: string, owner: string, m: ListingMetadata): Listing {
+  return {
+    id: cid,
+    type: m.type,
+    title: m.title,
+    location: m.location ?? '',
+    pricePerDay: Number(m.pricePerDay) || 0,
+    tags: m.tags ?? [],
+    impressionsPerDay: m.impressionsPerDay ?? 0,
+    audience: m.audience ?? '',
+    owner: owner || m.owner || '',
+    publisherType: m.publisherType ?? 'commercial',
+    ipfsCid: m.mediaCid ?? '',
+    verified: false,
+    description: m.description ?? '',
+    imageUrl: m.mediaCid ? ipfsUrl(m.mediaCid) : undefined,
+  };
+}
+
+/** Listings registered on-chain (newest first). Empty in mock mode / on error. */
+export async function getOnChainListings(): Promise<Listing[]> {
+  const treasury = getTreasury();
+  if (!treasury) return [];
+  try {
+    const conn = getConnection();
+    const sigs = await conn.getSignaturesForAddress(treasury, { limit: SCAN_LIMIT });
+    if (sigs.length === 0) return [];
+
+    const txs = await conn.getParsedTransactions(
+      sigs.map((s) => s.signature),
+      { maxSupportedTransactionVersion: 0, commitment: 'confirmed' }
+    );
+
+    const seen = new Set<string>();
+    const pending: Promise<Listing | null>[] = [];
+    for (const tx of txs) {
+      if (!tx || tx.meta?.err) continue;
+      const memo = extractMemo(tx);
+      if (!memo || !memo.startsWith(LISTING_MEMO_PREFIX)) continue;
+      const cid = memo.slice(LISTING_MEMO_PREFIX.length).trim();
+      if (!cid || seen.has(cid)) continue;
+      seen.add(cid);
+      const owner = firstSigner(tx);
+      pending.push(fetchMetadata(cid).then((m) => (m ? metaToListing(cid, owner, m) : null)));
+    }
+    const resolved = await Promise.all(pending);
+    return resolved.filter((l): l is Listing => l !== null);
+  } catch (e) {
+    console.error('[Screen Sync] getOnChainListings failed', e);
+    return [];
+  }
+}
+
+/** All listings: on-chain (newest first) followed by the demo seed catalog. */
+export async function getAllListings(): Promise<Listing[]> {
+  const onchain = await getOnChainListings();
+  return [...onchain, ...LISTINGS];
+}
+
+/** A single listing by id (seed id or on-chain metadata CID). */
+export async function getListingById(id: string): Promise<Listing | null> {
+  const seed = LISTINGS.find((l) => l.id === id);
+  if (seed) return seed;
+  const onchain = await getOnChainListings();
+  return onchain.find((l) => l.id === id) ?? null;
+}
+
+/** Listings registered by a specific wallet. */
+export async function getUserListings(owner: string): Promise<Listing[]> {
+  const onchain = await getOnChainListings();
+  return onchain.filter((l) => l.owner === owner);
+}

--- a/lib/listings.ts
+++ b/lib/listings.ts
@@ -11,12 +11,18 @@
 // marketplace is never empty. Everything degrades to seed-only in mock mode.
 import type { ParsedTransactionWithMeta } from '@solana/web3.js';
 import type { Listing, ListingType, PublisherType } from './mockData';
-import { LISTINGS } from './mockData';
+import { LISTINGS, TYPE_LABELS } from './mockData';
 import { getConnection, getTreasury } from './connection';
 import { ipfsUrl } from './pinata';
 
 const LISTING_MEMO_PREFIX = 'ss:list:v1:';
 const SCAN_LIMIT = 200;
+// Cap how many on-chain listings we resolve per scan — bounds IPFS fetches and
+// limits griefing (someone spamming registry memos can't unbounded-load the UI).
+const MAX_RESULTS = 60;
+
+const isListingType = (t: unknown): t is ListingType =>
+  typeof t === 'string' && Object.prototype.hasOwnProperty.call(TYPE_LABELS, t);
 
 /** Shape pinned to IPFS for each listing. */
 export interface ListingMetadata {
@@ -76,7 +82,9 @@ async function fetchMetadata(cid: string): Promise<ListingMetadata | null> {
   }
 }
 
-function metaToListing(cid: string, owner: string, m: ListingMetadata): Listing {
+function metaToListing(cid: string, owner: string, m: ListingMetadata): Listing | null {
+  // Untrusted IPFS metadata — validate the type before it reaches icon/CSS lookups.
+  if (!isListingType(m.type)) return null;
   return {
     id: cid,
     type: m.type,
@@ -112,6 +120,7 @@ export async function getOnChainListings(): Promise<Listing[]> {
     const seen = new Set<string>();
     const pending: Promise<Listing | null>[] = [];
     for (const tx of txs) {
+      if (pending.length >= MAX_RESULTS) break;
       if (!tx || tx.meta?.err) continue;
       const memo = extractMemo(tx);
       if (!memo || !memo.startsWith(LISTING_MEMO_PREFIX)) continue;

--- a/lib/listings.ts
+++ b/lib/listings.ts
@@ -12,8 +12,20 @@
 import type { ParsedTransactionWithMeta } from '@solana/web3.js';
 import type { Listing, ListingType, PublisherType } from './mockData';
 import { LISTINGS, TYPE_LABELS } from './mockData';
+import { LISTING_FEE_SOL } from './constants';
 import { getConnection, getTreasury } from './connection';
 import { ipfsUrl } from './pinata';
+
+/** Lamports the treasury actually received in this tx (anti-spam: a listing
+ *  memo only counts if the registry fee was really paid). */
+function lamportsReceived(tx: ParsedTransactionWithMeta, treasury: string): number {
+  if (!tx.meta) return 0;
+  const idx = tx.transaction.message.accountKeys.findIndex(
+    (k) => k.pubkey.toString() === treasury
+  );
+  if (idx < 0) return 0;
+  return (tx.meta.postBalances[idx] ?? 0) - (tx.meta.preBalances[idx] ?? 0);
+}
 
 const LISTING_MEMO_PREFIX = 'ss:list:v1:';
 const SCAN_LIMIT = 200;
@@ -117,6 +129,8 @@ export async function getOnChainListings(): Promise<Listing[]> {
       { maxSupportedTransactionVersion: 0, commitment: 'confirmed' }
     );
 
+    const treasuryStr = treasury.toBase58();
+    const minFeeLamports = Math.floor(LISTING_FEE_SOL * 1_000_000_000);
     const seen = new Set<string>();
     const pending: Promise<Listing | null>[] = [];
     for (const tx of txs) {
@@ -124,6 +138,8 @@ export async function getOnChainListings(): Promise<Listing[]> {
       if (!tx || tx.meta?.err) continue;
       const memo = extractMemo(tx);
       if (!memo || !memo.startsWith(LISTING_MEMO_PREFIX)) continue;
+      // Anti-spam: the registry fee must actually have been paid.
+      if (minFeeLamports > 0 && lamportsReceived(tx, treasuryStr) < minFeeLamports) continue;
       const cid = memo.slice(LISTING_MEMO_PREFIX.length).trim();
       if (!cid || seen.has(cid)) continue;
       seen.add(cid);

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -22,6 +22,8 @@ export interface Listing {
   ipfsCid: string;
   verified: boolean;
   description: string;
+  /** Gateway URL for the creative, set for on-chain listings (IPFS-hosted media). */
+  imageUrl?: string;
 }
 
 export const LISTINGS: Listing[] = [
@@ -178,5 +180,7 @@ export const PUBLISHER_LABELS: Record<PublisherType, string> = {
   private: 'Private',
 };
 
-/** Path to a listing's preview image (generated assets live in /public/listings). */
-export const listingImage = (l: Pick<Listing, 'id'>): string => `/listings/${l.id}.jpg`;
+/** Preview image for a listing: IPFS gateway URL for on-chain listings, else the
+ *  generated local asset (seed catalog lives in /public/listings). */
+export const listingImage = (l: Pick<Listing, 'id' | 'imageUrl'>): string =>
+  l.imageUrl || `/listings/${l.id}.jpg`;

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -26,7 +26,31 @@ export interface Listing {
   imageUrl?: string;
 }
 
+/**
+ * The house listing — Screen Sync's OWN website ad space. This is the real,
+ * bookable inventory of the self-contained MVP: $20 USDC 15-minute exclusive
+ * slots + frequency filler, served onto the marketing site via /api/ad + tag.js.
+ */
+export const HOUSE_LISTING_ID = 'house_web';
+
 export const LISTINGS: Listing[] = [
+  {
+    id: HOUSE_LISTING_ID,
+    type: 'website',
+    title: 'Screen Sync — Homepage Banner (Live)',
+    location: 'screensync site · above the fold',
+    pricePerDay: 20, // USDC per 15-min slot (see SLOT_PRICE_USDC)
+    tags: ['web3', 'live', 'house', 'crypto-native'],
+    impressionsPerDay: 5_000,
+    audience: 'Web3-curious founders, advertisers & publishers',
+    owner: 'Screen Sync',
+    publisherType: 'commercial',
+    ipfsCid: '',
+    verified: true,
+    description:
+      'The real deal — this banner lives on the Screen Sync marketing site and is served on-chain. Book an exclusive 15-minute slot ($20 USDC) or run filler between slots. Your creative is stored on IPFS, your payment settles on Solana, and your ad goes live on the site within a minute. This listing exists to demonstrate the full decentralized P2P advertising loop.',
+    imageUrl: '/listings/lst_004.jpg', // reuse the website-banner art until house art exists
+  },
   {
     id: 'lst_001',
     type: 'video-game',

--- a/lib/pinata.ts
+++ b/lib/pinata.ts
@@ -1,29 +1,39 @@
 import { validateFileContent } from './fileValidation';
+import { IPFS_GATEWAY } from './config';
 
-// Public IPFS gateway for reads; pinning keys live server-side (never expose secrets client-side).
-export const IPFS_GATEWAY =
-  process.env.NEXT_PUBLIC_IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs';
+// Public IPFS gateway for reads. Pinning keys live server-side (in /api/upload),
+// never in the client bundle.
+export { IPFS_GATEWAY };
 
-/** Stub: validate + upload a file to IPFS via Pinata and return its CID */
+/**
+ * Validate + upload an ad creative to IPFS and return its CID.
+ * Validates client-side for fast feedback, then pins via the server-side
+ * /api/upload route (which re-validates and holds the Pinata JWT).
+ * Returns a mock CID automatically when Pinata isn't configured.
+ */
 export async function uploadToIPFS(file: File): Promise<string> {
   const check = await validateFileContent(file);
   if (!check.valid) throw new Error(check.error ?? 'Invalid file');
-  console.log('[Screen Sync] uploadToIPFS stub → filename:', file.name);
-  await new Promise((r) => setTimeout(r, 1500));
-  const mockCid = `QmMock${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
-  return mockCid;
+
+  const form = new FormData();
+  form.append('file', file);
+
+  const res = await fetch('/api/upload', { method: 'POST', body: form });
+  const data = (await res.json().catch(() => ({}))) as { cid?: string; error?: string };
+  if (!res.ok || !data.cid) throw new Error(data.error || 'Upload failed');
+  return data.cid;
 }
 
-/** Stub: retrieve metadata from IPFS by CID */
+/** Retrieve JSON metadata from IPFS by CID (best-effort; returns a stub on failure). */
 export async function getFromIPFS(cid: string): Promise<Record<string, unknown>> {
-  console.log('[Screen Sync] getFromIPFS stub → cid:', cid);
-  await new Promise((r) => setTimeout(r, 400));
-  return { cid, status: 'mock', timestamp: Date.now() };
+  try {
+    const res = await fetch(`${IPFS_GATEWAY}/${cid}`);
+    if (res.ok) return (await res.json()) as Record<string, unknown>;
+  } catch {
+    /* fall through to stub */
+  }
+  return { cid, status: 'unavailable', timestamp: Date.now() };
 }
 
-/** Stub: pin an existing CID to Pinata */
-export async function pinByCID(cid: string): Promise<boolean> {
-  console.log('[Screen Sync] pinByCID stub → cid:', cid);
-  await new Promise((r) => setTimeout(r, 600));
-  return true;
-}
+/** Gateway URL for a creative CID (image/video src). */
+export const ipfsUrl = (cid: string): string => `${IPFS_GATEWAY}/${cid}`;

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,6 +1,44 @@
-// Pricing — adapted from reference/legacy-react-vite/utils/pricing.ts.
-// UI works in SOL (numbers); on-chain settlement uses lamports (see lib/format.ts).
-import { PLATFORM_FEE_BPS, BLOCKS_PER_DAY, SLOT_PREMIUM } from './constants';
+// Pricing.
+//
+// MVP (self-contained, USDC): flat $20 per 15-minute exclusive slot and flat
+// USDC/day filler tiers — see the USDC section below. The SOL-denominated
+// functions further down mirror the Phase 2 Anchor program's escrow math.
+import {
+  PLATFORM_FEE_BPS,
+  BLOCKS_PER_DAY,
+  SLOT_PREMIUM,
+  SLOT_PRICE_USDC,
+  FILLER_TIERS,
+  type FillerTier,
+} from './constants';
+
+// ---- MVP: USDC pricing ------------------------------------------------------
+
+export interface UsdcCost {
+  /** Line-item description for the breakdown UI. */
+  label: string;
+  /** Total USDC due (goes to the treasury in full). */
+  totalUsdc: number;
+}
+
+/** Cost of N exclusive 15-minute slots (flat $20 each). */
+export function slotCostUsdc(slotCount: number): UsdcCost {
+  return {
+    label: `${slotCount} × 15-min slot @ $${SLOT_PRICE_USDC}`,
+    totalUsdc: SLOT_PRICE_USDC * slotCount,
+  };
+}
+
+/** Cost of a filler run over `days` days at a tier (flat USDC/day). */
+export function fillerCostUsdc(days: number, tierId: FillerTier['id']): UsdcCost {
+  const tier = FILLER_TIERS.find((t) => t.id === tierId)!;
+  return {
+    label: `${days} day${days === 1 ? '' : 's'} × ${tier.label} filler @ $${tier.usdcPerDay}/day`,
+    totalUsdc: tier.usdcPerDay * days,
+  };
+}
+
+// ---- Phase 2 program: SOL-denominated escrow math ---------------------------
 
 /** Flat protocol fee (in SOL) on a base amount in SOL. */
 export const platformFee = (baseSol: number): number => baseSol * (PLATFORM_FEE_BPS / 10_000);

--- a/lib/solana.ts
+++ b/lib/solana.ts
@@ -1,33 +1,19 @@
-import type { Listing } from './mockData';
-import { LISTINGS } from './mockData';
-import { bookingTotal } from './pricing';
+import { PublicKey } from '@solana/web3.js';
+import { getConnection } from './connection';
+import { SOLANA_RPC_URL } from './config';
 
-// Phase 1 (hybrid): Devnet RPC. Override via env for mainnet/custom RPC later.
-export const SOLANA_RPC =
-  process.env.NEXT_PUBLIC_SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+// Back-compat: WalletProviderWrapper imports SOLANA_RPC as its RPC endpoint.
+export const SOLANA_RPC = SOLANA_RPC_URL;
 
-/** Stub: simulate creating a listing on-chain */
-export async function createListing(data: Partial<Listing>): Promise<string> {
-  console.log('[Screen Sync] createListing stub →', data);
-  await new Promise((r) => setTimeout(r, 1200));
-  return `mock_tx_${Date.now()}`;
-}
+const LAMPORTS = 1_000_000_000;
 
-/** Stub: simulate booking a listing. Real version transfers `total` (incl. protocol fee). */
-export async function bookListing(listingId: string, pricePerDay: number, days: number): Promise<string> {
-  const { base, fee, total } = bookingTotal(pricePerDay, days);
-  console.log(`[Screen Sync] bookListing stub → ${listingId} · ${days}d · base ${base} + fee ${fee} = ${total} SOL`);
-  await new Promise((r) => setTimeout(r, 1000));
-  return `mock_tx_${Date.now()}`;
-}
-
-/** Stub: fetch listings (returns mock data) */
-export async function getListings(): Promise<Listing[]> {
-  await new Promise((r) => setTimeout(r, 300));
-  return LISTINGS;
-}
-
-/** Stub: get SOL balance for a wallet */
-export async function getBalance(_walletAddress: string): Promise<number> {
-  return 42.69;
+/** Real SOL balance for a wallet. Returns 0 on any RPC/parse error. */
+export async function getBalance(walletAddress: string): Promise<number> {
+  try {
+    const lamports = await getConnection().getBalance(new PublicKey(walletAddress));
+    return lamports / LAMPORTS;
+  } catch (e) {
+    console.error('[Screen Sync] getBalance failed', e);
+    return 0;
+  }
 }

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { getConnection, getTreasury } from './connection';
+import { solToLamports } from './format';
+
+// SPL Memo program — lets us attach a human/parseable note to a tx with no
+// extra signer accounts (memo with zero keys just logs the data).
+const MEMO_PROGRAM_ID = new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');
+
+type SendFn = (
+  tx: Transaction,
+  connection: ReturnType<typeof getConnection>,
+  options?: { skipPreflight?: boolean }
+) => Promise<string>;
+
+/**
+ * Transfer `amountSol` to the treasury and attach an on-chain memo.
+ * Used for bookings (full amount) and listing registration (small fee).
+ * The treasury doubles as the on-chain registry: scanning its tx history
+ * surfaces every listing/booking. Returns the confirmed signature.
+ */
+export async function sendTreasuryTx(args: {
+  payer: PublicKey;
+  amountSol: number;
+  memo: string;
+  sendTransaction: SendFn;
+}): Promise<string> {
+  const treasury = getTreasury();
+  if (!treasury) throw new Error('Treasury wallet not configured');
+
+  const connection = getConnection();
+  const lamports = Number(solToLamports(args.amountSol));
+
+  const tx = new Transaction()
+    .add(SystemProgram.transfer({ fromPubkey: args.payer, toPubkey: treasury, lamports }))
+    .add(
+      new TransactionInstruction({
+        keys: [],
+        programId: MEMO_PROGRAM_ID,
+        data: Buffer.from(args.memo, 'utf8'),
+      })
+    );
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = args.payer;
+
+  const signature = await args.sendTransaction(tx, connection);
+  await connection.confirmTransaction(
+    { signature, blockhash, lastValidBlockHeight },
+    'confirmed'
+  );
+  return signature;
+}

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -6,7 +6,13 @@ import {
   Transaction,
   TransactionInstruction,
 } from '@solana/web3.js';
+import {
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createTransferCheckedInstruction,
+} from '@solana/spl-token';
 import { getConnection, getTreasury } from './connection';
+import { USDC_MINT, USDC_DECIMALS } from './config';
 import { solToLamports } from './format';
 
 // SPL Memo program — lets us attach a human/parseable note to a tx with no
@@ -39,6 +45,54 @@ export async function sendTreasuryTx(args: {
 
   const tx = new Transaction()
     .add(SystemProgram.transfer({ fromPubkey: args.payer, toPubkey: treasury, lamports }))
+    .add(
+      new TransactionInstruction({
+        keys: [],
+        programId: MEMO_PROGRAM_ID,
+        data: Buffer.from(args.memo, 'utf8'),
+      })
+    );
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = args.payer;
+
+  const signature = await args.sendTransaction(tx, connection);
+  await connection.confirmTransaction(
+    { signature, blockhash, lastValidBlockHeight },
+    'confirmed'
+  );
+  return signature;
+}
+
+/**
+ * Pay `amountUsdc` USDC to the treasury with an on-chain memo (booking record).
+ * Creates the treasury's USDC token account if needed (idempotent, payer =
+ * advertiser, ~0.002 SOL rent once). The advertiser signs one transaction:
+ * [ensure treasury ATA] + [transferChecked USDC] + [memo].
+ */
+export async function sendUsdcTreasuryTx(args: {
+  payer: PublicKey;
+  amountUsdc: number;
+  memo: string;
+  sendTransaction: SendFn;
+}): Promise<string> {
+  const treasury = getTreasury();
+  if (!treasury) throw new Error('Treasury wallet not configured');
+
+  const connection = getConnection();
+  const mint = new PublicKey(USDC_MINT);
+  const fromAta = getAssociatedTokenAddressSync(mint, args.payer);
+  const toAta = getAssociatedTokenAddressSync(mint, treasury);
+  const amount = BigInt(Math.round(args.amountUsdc * 10 ** USDC_DECIMALS));
+
+  const tx = new Transaction()
+    .add(
+      createAssociatedTokenAccountIdempotentInstruction(args.payer, toAta, treasury, mint)
+    )
+    .add(
+      createTransferCheckedInstruction(fromAta, mint, toAta, args.payer, amount, USDC_DECIMALS)
+    )
     .add(
       new TransactionInstruction({
         keys: [],

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack: (config) => {
+  webpack: (config, { webpack }) => {
     config.resolve.fallback = {
       ...config.resolve.fallback,
       fs: false,
@@ -8,8 +8,12 @@ const nextConfig = {
       path: false,
       crypto: false,
       stream: false,
-      buffer: false,
+      // @solana/web3.js needs Buffer in the browser (tx serialization / memo).
+      buffer: require.resolve('buffer/'),
     };
+    config.plugins.push(
+      new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] })
+    );
     return config;
   },
   transpilePackages: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@solana/wallet-adapter-react": "^0.15.35",
         "@solana/wallet-adapter-solflare": "^0.6.28",
         "@solana/web3.js": "^1.91.8",
+        "buffer": "^6.0.3",
         "next": "14.2.33",
         "react": "^18",
         "react-dom": "^18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "screensync-dapp",
       "version": "0.1.0",
       "dependencies": {
+        "@solana/spl-token": "^0.4.6",
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-adapter-phantom": "^0.9.24",
         "@solana/wallet-adapter-react": "^0.15.35",
@@ -1474,6 +1475,21 @@
       },
       "engines": {
         "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@solana/codecs": {
@@ -3184,6 +3200,268 @@
         }
       }
     },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.6.tgz",
+      "integrity": "sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.4",
+        "@solana/spl-token-metadata": "^0.1.4",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.91.6"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.4.tgz",
+      "integrity": "sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-preview.2",
+        "@solana/spl-type-length-value": "0.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.91.6"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-preview.2.tgz",
+      "integrity": "sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-data-structures": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/codecs-strings": "2.0.0-preview.2",
+        "@solana/options": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-preview.2.tgz",
+      "integrity": "sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.2.tgz",
+      "integrity": "sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.2.tgz",
+      "integrity": "sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-preview.2.tgz",
+      "integrity": "sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/errors": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-preview.2.tgz",
+      "integrity": "sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.js"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/options": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-preview.2.tgz",
+      "integrity": "sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-type-length-value": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz",
+      "integrity": "sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@solana/subscribable": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
@@ -4368,6 +4646,37 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
@@ -4911,6 +5220,13 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -4933,6 +5249,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@solana/wallet-adapter-react": "^0.15.35",
     "@solana/wallet-adapter-phantom": "^0.9.24",
     "@solana/wallet-adapter-solflare": "^0.6.28",
-    "@solana/web3.js": "^1.91.8"
+    "@solana/web3.js": "^1.91.8",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -8,21 +8,22 @@
     "start": "next start -p 3001"
   },
   "dependencies": {
-    "next": "14.2.33",
-    "react": "^18",
-    "react-dom": "^18",
+    "@solana/spl-token": "^0.4.6",
     "@solana/wallet-adapter-base": "^0.9.23",
-    "@solana/wallet-adapter-react": "^0.15.35",
     "@solana/wallet-adapter-phantom": "^0.9.24",
+    "@solana/wallet-adapter-react": "^0.15.35",
     "@solana/wallet-adapter-solflare": "^0.6.28",
     "@solana/web3.js": "^1.91.8",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "next": "14.2.33",
+    "react": "^18",
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "18.3.12",
-    "@types/react-dom": "18.3.1"
+    "@types/react-dom": "18.3.1",
+    "typescript": "^5"
   },
   "overrides": {
     "@types/react": "18.3.12",

--- a/program/.gitignore
+++ b/program/.gitignore
@@ -1,0 +1,6 @@
+.anchor
+target
+node_modules
+test-ledger
+**/*.rs.bk
+.DS_Store

--- a/program/Anchor.toml
+++ b/program/Anchor.toml
@@ -1,0 +1,23 @@
+[toolchain]
+anchor_version = "0.30.1"
+
+[features]
+resolution = true
+skip-lint = false
+
+[programs.devnet]
+screen_sync_marketplace = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[programs.localnet]
+screen_sync_marketplace = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+# Set to "Devnet" to deploy on devnet. Wallet is your deploy keypair (see program/README.md).
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = ["programs/*"]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/program/README.md
+++ b/program/README.md
@@ -1,0 +1,82 @@
+# screen_sync_marketplace — Anchor program (Phase 2)
+
+On-chain marketplace logic for Screen Sync: listing registration, slot/filler
+bookings, **SOL escrow**, and **2.5% protocol fee** settlement. This is the
+trustless layer that replaces the MVP's custodial direct-transfer payments.
+
+> **Status: scaffold.** Code is written but **not yet built/deployed** — that
+> needs the Solana + Anchor toolchain and your deploy wallet (neither was
+> available in the session that wrote it). Build + test + audit before mainnet.
+
+## Layout
+```
+program/
+  Anchor.toml
+  Cargo.toml                                  workspace
+  programs/screen_sync_marketplace/
+    Cargo.toml
+    src/lib.rs                                the program
+  tests/screen_sync_marketplace.ts            test skeleton (happy paths)
+  package.json  tsconfig.json                 anchor test harness
+```
+
+## Prerequisites (one-time)
+```bash
+# Solana CLI
+sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+# Anchor via avm
+cargo install --git https://github.com/coral-xyz/anchor avm --locked
+avm install 0.30.1 && avm use 0.30.1
+# A deploy wallet (THIS is the "project wallet to deploy smart contracts")
+solana-keygen new -o ~/.config/solana/id.json     # save the seed phrase securely
+solana config set --url devnet
+solana airdrop 2
+```
+
+## Build / test / deploy
+```bash
+cd program
+anchor build                 # compiles the program + generates the IDL
+anchor keys sync             # writes the real program id into lib.rs + Anchor.toml
+anchor build                 # rebuild so the embedded id matches
+anchor test                  # runs tests on a local validator
+# Devnet:
+anchor deploy --provider.cluster devnet
+```
+After `anchor keys sync`, replace the placeholder `declare_id!` — the command does
+this for you; commit the change.
+
+## Instructions (Phase 2a core)
+| Ix | Signer | Effect |
+|----|--------|--------|
+| `initialize_config` | admin | Set treasury, oracle, fee_bps. PDA `["config"]`. |
+| `update_config` | admin | Update fee/oracle/treasury/pause. |
+| `register_listing` | publisher | Create Listing PDA `["listing", owner, listing_id]`. |
+| `update_listing` | publisher | Update rate/mode/active. |
+| `book_slot` | advertiser | Reserve block(s) on a date; escrow `slotPrice×count + fee`. |
+| `book_filler` | advertiser | Reserve filler over a range; escrow `rate×tier×days + fee`. |
+| `settle_booking` | oracle/admin | Publisher gets amount, treasury gets fee, booking closes. |
+| `cancel_booking` | advertiser | Pre-start refund (escrow + rent); frees slots. |
+
+Pricing mirrors `lib/pricing.ts` / `lib/constants.ts` exactly (250 bps fee, 8
+blocks/day, 1.5× slot premium, filler tiers 25/50/100%). All math is integer
+lamports with checked arithmetic.
+
+## Wiring back into the dApp (when deployed)
+Swap the MVP's direct-transfer path for program calls, keeping `lib/*` signatures:
+- `lib/transactions.ts` `sendTreasuryTx` → build `book_slot` / `book_filler` ixs.
+- `app/list` registration → `register_listing` ix.
+- `lib/listings.ts` reads → fetch `Listing` PDAs (or DAS once Core NFTs land) +
+  read `DayLedger` for `lib/availability.ts` instead of the mock.
+- Copy the generated IDL + types from `program/target/idl` & `target/types` into
+  the dApp and use `@coral-xyz/anchor` to call the program.
+
+## Not yet implemented (later phases — see ../docs/SMART-CONTRACTS.md)
+- Metaplex Core NFTs (listings/creatives/contract receipts).
+- Proof-of-display (Bubblegum cNFT) + `record_delivery` + dispute resolution.
+- USDC (SPL) escrow path (Config can be extended with `accepted_mint`).
+- Strict multi-day on-chain filler-cap enforcement.
+
+## Security
+Apply the Phase 2 checklist in [`../docs/SECURITY.md`](../docs/SECURITY.md) and
+run the Solana MCP `program_autofixer` before any audit/deploy.

--- a/program/package.json
+++ b/program/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "screen-sync-program",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "anchor test"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.30.1"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.5",
+    "@types/chai": "^4.3.11",
+    "@types/mocha": "^9.1.1",
+    "chai": "^4.3.10",
+    "mocha": "^9.2.2",
+    "ts-mocha": "^10.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/program/programs/screen_sync_marketplace/Cargo.toml
+++ b/program/programs/screen_sync_marketplace/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "screen_sync_marketplace"
+version = "0.1.0"
+description = "Screen Sync — on-chain advertising marketplace (escrow + fees)"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "screen_sync_marketplace"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+# Required for DayLedger init_if_needed (first booking on a date creates the ledger).
+init-if-needed = ["anchor-lang/init-if-needed"]
+
+[dependencies]
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }

--- a/program/programs/screen_sync_marketplace/src/lib.rs
+++ b/program/programs/screen_sync_marketplace/src/lib.rs
@@ -1,0 +1,559 @@
+//! Screen Sync — on-chain advertising marketplace (Phase 2a core).
+//!
+//! Mirrors the dApp's pricing (`lib/pricing.ts`, `lib/constants.ts`):
+//!   * protocol fee = 2.5% (250 bps)
+//!   * slot price   = base_rate / blocks_per_day * 1.5  (SLOT_PREMIUM)
+//!   * filler price = base_rate * tier_factor * days     (0.25 / 0.5 / 1.0)
+//!
+//! Funds flow: an advertiser escrows `amount + fee` into a per-booking PDA.
+//! On `settle_booking` the publisher receives `amount`, the treasury receives
+//! `fee`, and the booking account is closed (rent returns to the advertiser).
+//! On `cancel_booking` (before the start date) the full escrow + rent refunds.
+//!
+//! NOT YET IMPLEMENTED (later Phase 2/3, see docs/SMART-CONTRACTS.md):
+//!   * Metaplex Core NFTs for listings/creatives/contracts
+//!   * proof-of-display (Bubblegum cNFT) + record_delivery + disputes
+//!   * USDC (SPL) escrow path (Config.accepted_mint is reserved for this)
+//!   * strict on-chain filler-cap enforcement across a date range
+//!
+//! Replace the placeholder program id below via `anchor keys sync` after the
+//! first `anchor build` (see program/README.md).
+
+use anchor_lang::prelude::*;
+use anchor_lang::system_program::{self, Transfer};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+// ---- Protocol constants (keep in sync with lib/constants.ts) --------------
+const PLATFORM_FEE_BPS: u64 = 250; // 2.5%
+const BPS_DENOMINATOR: u64 = 10_000;
+const SLOT_PREMIUM_NUM: u64 = 3; // 1.5x expressed as 3/2 for integer math
+const SLOT_PREMIUM_DEN: u64 = 2;
+const MAX_BLOCKS_PER_DAY: u8 = 8; // slot_bitmap is a u8
+
+const MODE_EXCLUSIVE: u8 = 0;
+const MODE_ROTATING: u8 = 1;
+
+const KIND_SLOT: u8 = 0;
+const KIND_FILLER: u8 = 1;
+
+const STATUS_ESCROWED: u8 = 0;
+const STATUS_SETTLED: u8 = 1;
+const STATUS_REFUNDED: u8 = 2;
+
+/// Filler tier factors in bps: Low 25%, Medium 50%, High 100% (lib/constants FILLER_TIERS).
+const FILLER_TIER_BPS: [u64; 3] = [2_500, 5_000, 10_000];
+
+// ---- Pricing helpers ------------------------------------------------------
+fn platform_fee(base: u64) -> Result<u64> {
+    base.checked_mul(PLATFORM_FEE_BPS)
+        .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+        .ok_or(error!(MarketError::MathOverflow))
+}
+
+fn slot_price(base_rate: u64, blocks_per_day: u8) -> Result<u64> {
+    // base_rate / blocks_per_day * 1.5  ->  base_rate * 3 / (blocks_per_day * 2)
+    let denom = (blocks_per_day as u64)
+        .checked_mul(SLOT_PREMIUM_DEN)
+        .ok_or(error!(MarketError::MathOverflow))?;
+    base_rate
+        .checked_mul(SLOT_PREMIUM_NUM)
+        .and_then(|v| v.checked_div(denom))
+        .ok_or(error!(MarketError::MathOverflow))
+}
+
+#[program]
+pub mod screen_sync_marketplace {
+    use super::*;
+
+    /// One-time protocol setup. Signer becomes admin.
+    pub fn initialize_config(ctx: Context<InitializeConfig>, fee_bps: u16, oracle: Pubkey) -> Result<()> {
+        require!(fee_bps as u64 <= BPS_DENOMINATOR, MarketError::InvalidFee);
+        let cfg = &mut ctx.accounts.config;
+        cfg.admin = ctx.accounts.admin.key();
+        cfg.treasury = ctx.accounts.treasury.key();
+        cfg.oracle = oracle;
+        cfg.fee_bps = fee_bps;
+        cfg.paused = false;
+        cfg.bump = ctx.bumps.config;
+        Ok(())
+    }
+
+    /// Admin: update treasury / oracle / fee / pause.
+    pub fn update_config(
+        ctx: Context<UpdateConfig>,
+        fee_bps: u16,
+        oracle: Pubkey,
+        treasury: Pubkey,
+        paused: bool,
+    ) -> Result<()> {
+        require!(fee_bps as u64 <= BPS_DENOMINATOR, MarketError::InvalidFee);
+        let cfg = &mut ctx.accounts.config;
+        cfg.fee_bps = fee_bps;
+        cfg.oracle = oracle;
+        cfg.treasury = treasury;
+        cfg.paused = paused;
+        Ok(())
+    }
+
+    /// Publisher registers an ad space. `listing_id` is a client-chosen nonce
+    /// (e.g. a timestamp) that namespaces the listing PDA under the owner.
+    pub fn register_listing(
+        ctx: Context<RegisterListing>,
+        listing_id: u64,
+        base_rate: u64,
+        blocks_per_day: u8,
+        mode: u8,
+    ) -> Result<()> {
+        require!(!ctx.accounts.config.paused, MarketError::Paused);
+        require!(base_rate > 0, MarketError::InvalidAmount);
+        require!(
+            blocks_per_day > 0 && blocks_per_day <= MAX_BLOCKS_PER_DAY,
+            MarketError::InvalidBlocks
+        );
+        require!(mode == MODE_EXCLUSIVE || mode == MODE_ROTATING, MarketError::InvalidMode);
+
+        let listing = &mut ctx.accounts.listing;
+        listing.owner = ctx.accounts.owner.key();
+        listing.listing_id = listing_id;
+        listing.base_rate = base_rate;
+        listing.blocks_per_day = blocks_per_day;
+        listing.mode = mode;
+        listing.active = true;
+        listing.bump = ctx.bumps.listing;
+        Ok(())
+    }
+
+    /// Publisher updates rate / mode / active flag.
+    pub fn update_listing(ctx: Context<UpdateListing>, base_rate: u64, mode: u8, active: bool) -> Result<()> {
+        require!(base_rate > 0, MarketError::InvalidAmount);
+        require!(mode == MODE_EXCLUSIVE || mode == MODE_ROTATING, MarketError::InvalidMode);
+        let listing = &mut ctx.accounts.listing;
+        listing.base_rate = base_rate;
+        listing.mode = mode;
+        listing.active = active;
+        Ok(())
+    }
+
+    /// Advertiser books exclusive time block(s) on a single date.
+    /// `slot_mask` has one bit per 3h block; conflicting bits are rejected.
+    pub fn book_slot(ctx: Context<BookSlot>, nonce: u64, date: u32, slot_mask: u8) -> Result<()> {
+        let listing = &ctx.accounts.listing;
+        require!(!ctx.accounts.config.paused, MarketError::Paused);
+        require!(listing.active, MarketError::ListingInactive);
+        require!(slot_mask != 0, MarketError::InvalidSlots);
+        // All requested bits must be within the listing's block count.
+        let valid_bits: u16 = (1u16 << listing.blocks_per_day) - 1;
+        require!((slot_mask as u16 & !valid_bits) == 0, MarketError::InvalidSlots);
+
+        let ledger = &mut ctx.accounts.day_ledger;
+        // Initialise the ledger on first use for this (listing, date).
+        if ledger.listing == Pubkey::default() {
+            ledger.listing = listing.key();
+            ledger.date = date;
+            ledger.bump = ctx.bumps.day_ledger;
+        }
+        require!(ledger.date == date, MarketError::LedgerMismatch);
+        // No overlap with already-booked blocks.
+        require!((ledger.slot_bitmap & slot_mask) == 0, MarketError::SlotTaken);
+
+        let count = slot_mask.count_ones() as u64;
+        let amount = slot_price(listing.base_rate, listing.blocks_per_day)?
+            .checked_mul(count)
+            .ok_or(error!(MarketError::MathOverflow))?;
+        let fee = platform_fee(amount)?;
+        let total = amount.checked_add(fee).ok_or(error!(MarketError::MathOverflow))?;
+
+        escrow_in(
+            &ctx.accounts.advertiser,
+            &ctx.accounts.booking.to_account_info(),
+            &ctx.accounts.system_program,
+            total,
+        )?;
+
+        ledger.slot_bitmap |= slot_mask;
+
+        let booking = &mut ctx.accounts.booking;
+        booking.listing = listing.key();
+        booking.advertiser = ctx.accounts.advertiser.key();
+        booking.kind = KIND_SLOT;
+        booking.start_date = date;
+        booking.end_date = date;
+        booking.slots = slot_mask;
+        booking.filler_tier = 0;
+        booking.amount = amount;
+        booking.fee = fee;
+        booking.escrow = total;
+        booking.status = STATUS_ESCROWED;
+        booking.nonce = nonce;
+        booking.bump = ctx.bumps.booking;
+        Ok(())
+    }
+
+    /// Advertiser books filler over a date range at a tier (Low/Medium/High).
+    /// Filler runs in the gaps and does not consume exclusive slots.
+    pub fn book_filler(
+        ctx: Context<BookFiller>,
+        nonce: u64,
+        start_date: u32,
+        end_date: u32,
+        tier: u8,
+    ) -> Result<()> {
+        let listing = &ctx.accounts.listing;
+        require!(!ctx.accounts.config.paused, MarketError::Paused);
+        require!(listing.active, MarketError::ListingInactive);
+        require!(end_date >= start_date, MarketError::InvalidDates);
+        require!((tier as usize) < FILLER_TIER_BPS.len(), MarketError::InvalidTier);
+
+        let days = (end_date - start_date + 1) as u64;
+        let factor_bps = FILLER_TIER_BPS[tier as usize];
+        // amount = base_rate * factor * days
+        let amount = listing
+            .base_rate
+            .checked_mul(factor_bps)
+            .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+            .and_then(|v| v.checked_mul(days))
+            .ok_or(error!(MarketError::MathOverflow))?;
+        require!(amount > 0, MarketError::InvalidAmount);
+        let fee = platform_fee(amount)?;
+        let total = amount.checked_add(fee).ok_or(error!(MarketError::MathOverflow))?;
+
+        escrow_in(
+            &ctx.accounts.advertiser,
+            &ctx.accounts.booking.to_account_info(),
+            &ctx.accounts.system_program,
+            total,
+        )?;
+
+        let booking = &mut ctx.accounts.booking;
+        booking.listing = listing.key();
+        booking.advertiser = ctx.accounts.advertiser.key();
+        booking.kind = KIND_FILLER;
+        booking.start_date = start_date;
+        booking.end_date = end_date;
+        booking.slots = 0;
+        booking.filler_tier = tier;
+        booking.amount = amount;
+        booking.fee = fee;
+        booking.escrow = total;
+        booking.status = STATUS_ESCROWED;
+        booking.nonce = nonce;
+        booking.bump = ctx.bumps.booking;
+        Ok(())
+    }
+
+    /// Oracle/admin settles a booking: publisher gets `amount`, treasury gets
+    /// `fee`, booking closes (rent back to advertiser).
+    pub fn settle_booking(ctx: Context<SettleBooking>) -> Result<()> {
+        let booking = &ctx.accounts.booking;
+        require!(booking.status == STATUS_ESCROWED, MarketError::NotEscrowed);
+        let amount = booking.amount;
+        let fee = booking.fee;
+
+        // Move escrow out of the program-owned booking PDA.
+        let booking_ai = ctx.accounts.booking.to_account_info();
+        **booking_ai.try_borrow_mut_lamports()? -= amount + fee;
+        **ctx.accounts.publisher.try_borrow_mut_lamports()? += amount;
+        **ctx.accounts.treasury.try_borrow_mut_lamports()? += fee;
+
+        ctx.accounts.booking.status = STATUS_SETTLED;
+        // Anchor `close = advertiser` returns the remaining rent on exit.
+        Ok(())
+    }
+
+    /// Advertiser cancels before the start date: full escrow + rent refunded,
+    /// any reserved slots are freed.
+    pub fn cancel_booking(ctx: Context<CancelBooking>) -> Result<()> {
+        let booking = &ctx.accounts.booking;
+        require!(booking.status == STATUS_ESCROWED, MarketError::NotEscrowed);
+
+        let today = (Clock::get()?.unix_timestamp / 86_400) as u32;
+        require!(today < booking.start_date, MarketError::AlreadyStarted);
+
+        // Free reserved slots for slot bookings.
+        if booking.kind == KIND_SLOT {
+            let ledger = &mut ctx.accounts.day_ledger;
+            require!(ledger.date == booking.start_date, MarketError::LedgerMismatch);
+            ledger.slot_bitmap &= !booking.slots;
+        }
+
+        ctx.accounts.booking.status = STATUS_REFUNDED;
+        // Anchor `close = advertiser` returns escrow + rent (all PDA lamports).
+        Ok(())
+    }
+}
+
+/// CPI: move `lamports` from a system-owned signer into the booking PDA.
+fn escrow_in<'info>(
+    from: &Signer<'info>,
+    to: &AccountInfo<'info>,
+    system_program: &Program<'info, System>,
+    lamports: u64,
+) -> Result<()> {
+    system_program::transfer(
+        CpiContext::new(
+            system_program.to_account_info(),
+            Transfer { from: from.to_account_info(), to: to.clone() },
+        ),
+        lamports,
+    )
+}
+
+// ---- Accounts -------------------------------------------------------------
+
+#[derive(Accounts)]
+pub struct InitializeConfig<'info> {
+    #[account(mut)]
+    pub admin: Signer<'info>,
+    /// CHECK: treasury is a destination pubkey recorded in config; validated on settle.
+    pub treasury: UncheckedAccount<'info>,
+    #[account(
+        init,
+        payer = admin,
+        space = 8 + Config::INIT_SPACE,
+        seeds = [b"config"],
+        bump
+    )]
+    pub config: Account<'info, Config>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateConfig<'info> {
+    #[account(constraint = admin.key() == config.admin @ MarketError::Unauthorized)]
+    pub admin: Signer<'info>,
+    #[account(mut, seeds = [b"config"], bump = config.bump)]
+    pub config: Account<'info, Config>,
+}
+
+#[derive(Accounts)]
+#[instruction(listing_id: u64)]
+pub struct RegisterListing<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    #[account(seeds = [b"config"], bump = config.bump)]
+    pub config: Account<'info, Config>,
+    #[account(
+        init,
+        payer = owner,
+        space = 8 + Listing::INIT_SPACE,
+        seeds = [b"listing", owner.key().as_ref(), &listing_id.to_le_bytes()],
+        bump
+    )]
+    pub listing: Account<'info, Listing>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateListing<'info> {
+    #[account(constraint = owner.key() == listing.owner @ MarketError::Unauthorized)]
+    pub owner: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [b"listing", listing.owner.as_ref(), &listing.listing_id.to_le_bytes()],
+        bump = listing.bump
+    )]
+    pub listing: Account<'info, Listing>,
+}
+
+#[derive(Accounts)]
+#[instruction(nonce: u64, date: u32)]
+pub struct BookSlot<'info> {
+    #[account(mut)]
+    pub advertiser: Signer<'info>,
+    #[account(seeds = [b"config"], bump = config.bump)]
+    pub config: Account<'info, Config>,
+    #[account(
+        seeds = [b"listing", listing.owner.as_ref(), &listing.listing_id.to_le_bytes()],
+        bump = listing.bump
+    )]
+    pub listing: Account<'info, Listing>,
+    #[account(
+        init_if_needed,
+        payer = advertiser,
+        space = 8 + DayLedger::INIT_SPACE,
+        seeds = [b"day", listing.key().as_ref(), &date.to_le_bytes()],
+        bump
+    )]
+    pub day_ledger: Account<'info, DayLedger>,
+    #[account(
+        init,
+        payer = advertiser,
+        space = 8 + Booking::INIT_SPACE,
+        seeds = [b"booking", listing.key().as_ref(), advertiser.key().as_ref(), &nonce.to_le_bytes()],
+        bump
+    )]
+    pub booking: Account<'info, Booking>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(nonce: u64)]
+pub struct BookFiller<'info> {
+    #[account(mut)]
+    pub advertiser: Signer<'info>,
+    #[account(seeds = [b"config"], bump = config.bump)]
+    pub config: Account<'info, Config>,
+    #[account(
+        seeds = [b"listing", listing.owner.as_ref(), &listing.listing_id.to_le_bytes()],
+        bump = listing.bump
+    )]
+    pub listing: Account<'info, Listing>,
+    #[account(
+        init,
+        payer = advertiser,
+        space = 8 + Booking::INIT_SPACE,
+        seeds = [b"booking", listing.key().as_ref(), advertiser.key().as_ref(), &nonce.to_le_bytes()],
+        bump
+    )]
+    pub booking: Account<'info, Booking>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct SettleBooking<'info> {
+    #[account(
+        constraint = (authority.key() == config.oracle || authority.key() == config.admin)
+            @ MarketError::Unauthorized
+    )]
+    pub authority: Signer<'info>,
+    #[account(seeds = [b"config"], bump = config.bump)]
+    pub config: Account<'info, Config>,
+    #[account(
+        seeds = [b"listing", listing.owner.as_ref(), &listing.listing_id.to_le_bytes()],
+        bump = listing.bump
+    )]
+    pub listing: Account<'info, Listing>,
+    #[account(
+        mut,
+        has_one = listing @ MarketError::ListingMismatch,
+        has_one = advertiser @ MarketError::Unauthorized,
+        close = advertiser,
+        seeds = [b"booking", booking.listing.as_ref(), booking.advertiser.as_ref(), &booking.nonce.to_le_bytes()],
+        bump = booking.bump
+    )]
+    pub booking: Account<'info, Booking>,
+    /// CHECK: must be the listing owner (publisher); validated by address.
+    #[account(mut, address = listing.owner @ MarketError::Unauthorized)]
+    pub publisher: UncheckedAccount<'info>,
+    /// CHECK: must be the configured treasury; validated by address.
+    #[account(mut, address = config.treasury @ MarketError::Unauthorized)]
+    pub treasury: UncheckedAccount<'info>,
+    /// CHECK: rent recipient on close; must match the booking's advertiser.
+    #[account(mut, address = booking.advertiser @ MarketError::Unauthorized)]
+    pub advertiser: UncheckedAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct CancelBooking<'info> {
+    #[account(mut, constraint = advertiser.key() == booking.advertiser @ MarketError::Unauthorized)]
+    pub advertiser: Signer<'info>,
+    #[account(
+        mut,
+        has_one = advertiser @ MarketError::Unauthorized,
+        close = advertiser,
+        seeds = [b"booking", booking.listing.as_ref(), booking.advertiser.as_ref(), &booking.nonce.to_le_bytes()],
+        bump = booking.bump
+    )]
+    pub booking: Account<'info, Booking>,
+    /// Slot bookings free their reserved blocks; pass the matching DayLedger.
+    #[account(
+        mut,
+        seeds = [b"day", booking.listing.as_ref(), &booking.start_date.to_le_bytes()],
+        bump = day_ledger.bump
+    )]
+    pub day_ledger: Account<'info, DayLedger>,
+    pub system_program: Program<'info, System>,
+}
+
+// ---- State ----------------------------------------------------------------
+
+#[account]
+#[derive(InitSpace)]
+pub struct Config {
+    pub admin: Pubkey,
+    pub treasury: Pubkey,
+    pub oracle: Pubkey,
+    pub fee_bps: u16,
+    pub paused: bool,
+    pub bump: u8,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct Listing {
+    pub owner: Pubkey,
+    pub listing_id: u64,
+    pub base_rate: u64, // lamports per day
+    pub blocks_per_day: u8,
+    pub mode: u8,
+    pub active: bool,
+    pub bump: u8,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct DayLedger {
+    pub listing: Pubkey,
+    pub date: u32,       // days since unix epoch
+    pub slot_bitmap: u8, // 1 bit per 3h block
+    pub filler_used: u16,
+    pub bump: u8,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct Booking {
+    pub listing: Pubkey,
+    pub advertiser: Pubkey,
+    pub kind: u8, // 0 slot, 1 filler
+    pub start_date: u32,
+    pub end_date: u32,
+    pub slots: u8, // reserved block bitmap (slot kind)
+    pub filler_tier: u8,
+    pub amount: u64, // subtotal (lamports)
+    pub fee: u64,
+    pub escrow: u64, // amount + fee held by this PDA
+    pub status: u8,
+    pub nonce: u64,
+    pub bump: u8,
+}
+
+// ---- Errors ---------------------------------------------------------------
+
+#[error_code]
+pub enum MarketError {
+    #[msg("Arithmetic overflow")]
+    MathOverflow,
+    #[msg("Invalid fee (must be <= 10000 bps)")]
+    InvalidFee,
+    #[msg("Invalid amount")]
+    InvalidAmount,
+    #[msg("Invalid blocks_per_day")]
+    InvalidBlocks,
+    #[msg("Invalid listing mode")]
+    InvalidMode,
+    #[msg("Invalid slot mask")]
+    InvalidSlots,
+    #[msg("Invalid filler tier")]
+    InvalidTier,
+    #[msg("Invalid date range")]
+    InvalidDates,
+    #[msg("Protocol is paused")]
+    Paused,
+    #[msg("Listing is inactive")]
+    ListingInactive,
+    #[msg("One or more requested slots are already booked")]
+    SlotTaken,
+    #[msg("Day ledger does not match the requested date")]
+    LedgerMismatch,
+    #[msg("Booking does not match the provided listing")]
+    ListingMismatch,
+    #[msg("Booking is not in the escrowed state")]
+    NotEscrowed,
+    #[msg("Booking has already started; cannot cancel")]
+    AlreadyStarted,
+    #[msg("Unauthorized")]
+    Unauthorized,
+}

--- a/program/tests/screen_sync_marketplace.ts
+++ b/program/tests/screen_sync_marketplace.ts
@@ -1,0 +1,101 @@
+// Happy-path tests for screen_sync_marketplace.
+// Run with: anchor test   (requires the Solana + Anchor toolchain installed).
+//
+// This is a starting skeleton — extend with conflict/refund/auth cases:
+//   * book_slot rejects overlapping slot masks (SlotTaken)
+//   * cancel_booking refunds escrow + frees slots, and rejects after start_date
+//   * settle_booking pays publisher `amount` and treasury `fee`, rejects non-oracle
+//   * register_listing rejects invalid blocks/mode; fee math matches lib/pricing.ts
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { PublicKey, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { ScreenSyncMarketplace } from "../target/types/screen_sync_marketplace";
+import { assert } from "chai";
+
+const enc = (s: string) => Buffer.from(s);
+const u64 = (n: number | bigint) => new anchor.BN(n.toString());
+const le = (n: number, bytes: number) => {
+  const b = Buffer.alloc(bytes);
+  b.writeBigUInt64LE(BigInt(n));
+  return b.subarray(0, bytes);
+};
+
+describe("screen_sync_marketplace", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+  const program = anchor.workspace
+    .ScreenSyncMarketplace as Program<ScreenSyncMarketplace>;
+
+  const admin = provider.wallet as anchor.Wallet;
+  const treasury = Keypair.generate();
+  const oracle = admin.payer; // admin doubles as oracle for the test
+
+  const [configPda] = PublicKey.findProgramAddressSync([enc("config")], program.programId);
+
+  const listingId = Date.now();
+  const [listingPda] = PublicKey.findProgramAddressSync(
+    [enc("listing"), admin.publicKey.toBuffer(), le(listingId, 8)],
+    program.programId
+  );
+
+  const baseRate = 0.8 * LAMPORTS_PER_SOL; // lamports/day
+  const blocksPerDay = 8;
+
+  it("initializes config", async () => {
+    await program.methods
+      .initializeConfig(250, oracle.publicKey)
+      .accounts({ admin: admin.publicKey, treasury: treasury.publicKey })
+      .rpc();
+    const cfg = await program.account.config.fetch(configPda);
+    assert.equal(cfg.feeBps, 250);
+    assert.ok(cfg.treasury.equals(treasury.publicKey));
+  });
+
+  it("registers a listing", async () => {
+    await program.methods
+      .registerListing(u64(listingId), u64(baseRate), blocksPerDay, 0)
+      .accounts({ owner: admin.publicKey, config: configPda, listing: listingPda })
+      .rpc();
+    const l = await program.account.listing.fetch(listingPda);
+    assert.equal(l.baseRate.toString(), baseRate.toString());
+    assert.isTrue(l.active);
+  });
+
+  it("books a slot and escrows funds", async () => {
+    const nonce = Date.now();
+    const date = Math.floor(Date.now() / 86_400_000) + 3; // 3 days out
+    const slotMask = 0b0000_0011; // two blocks
+
+    const [bookingPda] = PublicKey.findProgramAddressSync(
+      [enc("booking"), listingPda.toBuffer(), admin.publicKey.toBuffer(), le(nonce, 8)],
+      program.programId
+    );
+    const [dayPda] = PublicKey.findProgramAddressSync(
+      [enc("day"), listingPda.toBuffer(), le(date, 4)],
+      program.programId
+    );
+
+    await program.methods
+      .bookSlot(u64(nonce), date, slotMask)
+      .accounts({
+        advertiser: admin.publicKey,
+        config: configPda,
+        listing: listingPda,
+        dayLedger: dayPda,
+        booking: bookingPda,
+      })
+      .rpc();
+
+    const b = await program.account.booking.fetch(bookingPda);
+    // slotPrice = baseRate/8 * 1.5 ; amount = slotPrice * 2 ; fee = 2.5%
+    const slotPrice = Math.floor((baseRate * 3) / (blocksPerDay * 2));
+    const amount = slotPrice * 2;
+    const fee = Math.floor((amount * 250) / 10_000);
+    assert.equal(b.amount.toString(), amount.toString());
+    assert.equal(b.fee.toString(), fee.toString());
+    assert.equal(b.escrow.toString(), (amount + fee).toString());
+
+    const day = await program.account.dayLedger.fetch(dayPda);
+    assert.equal(day.slotBitmap, slotMask);
+  });
+});

--- a/program/tsconfig.json
+++ b/program/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai", "node"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "target": "es2020",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  }
+}

--- a/public/tag.js
+++ b/public/tag.js
@@ -1,0 +1,58 @@
+/* Screen Sync ad tag — embed on any website to serve on-chain booked ads.
+ *
+ * Usage (paste where the ad should appear):
+ *   <script async src="https://YOUR-DAPP.netlify.app/tag.js"
+ *           data-listing="house_web" data-width="728" data-height="90"></script>
+ *
+ * The tag asks the dApp's /api/ad which creative is booked for the current
+ * 15-minute window (exclusive slot > filler rotation > house ad), renders it,
+ * and refreshes every 60 seconds. No cookies, no tracking, ~1KB.
+ */
+(function () {
+  'use strict';
+
+  var script = document.currentScript;
+  if (!script) return;
+
+  var base = new URL(script.src).origin;
+  var listing = script.getAttribute('data-listing') || 'house_web';
+  var width = script.getAttribute('data-width') || '728';
+  var height = script.getAttribute('data-height') || '90';
+  var REFRESH_MS = 60000;
+
+  // Container replaces the script tag's position in the page.
+  var box = document.createElement('div');
+  box.className = 'screensync-ad';
+  box.style.cssText =
+    'display:block;max-width:' + width + 'px;width:100%;margin:0 auto;' +
+    'line-height:0;overflow:hidden;border-radius:6px;';
+  script.parentNode.insertBefore(box, script);
+
+  var link = document.createElement('a');
+  link.target = '_blank';
+  link.rel = 'noopener sponsored';
+  var img = document.createElement('img');
+  img.alt = 'Advertisement — served on-chain by Screen Sync';
+  img.style.cssText =
+    'width:100%;height:auto;max-height:' + height + 'px;object-fit:cover;display:block;';
+  img.loading = 'lazy';
+  link.appendChild(img);
+  box.appendChild(link);
+
+  function setAd(ad) {
+    if (!ad || !ad.imageUrl) return;
+    if (img.src !== ad.imageUrl) img.src = ad.imageUrl;
+    link.href = ad.clickUrl || base;
+    box.setAttribute('data-kind', ad.kind || 'house');
+  }
+
+  function load() {
+    fetch(base + '/api/ad?listing=' + encodeURIComponent(listing), { mode: 'cors' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(setAd)
+      .catch(function () { /* keep the last ad on transient failures */ });
+  }
+
+  load();
+  setInterval(load, REFRESH_MS);
+})();

--- a/styles/ContractBuilder.module.css
+++ b/styles/ContractBuilder.module.css
@@ -306,6 +306,14 @@
   color: var(--cherry-bright);
 }
 
+.payNote {
+  margin-top: 0.6rem;
+  font-size: 0.74rem;
+  line-height: 1.5;
+  color: var(--beige-dim);
+  text-align: center;
+}
+
 .makeOffer { margin-top: 0.6rem; }
 
 .ownerRow {

--- a/styles/ContractBuilder.module.css
+++ b/styles/ContractBuilder.module.css
@@ -306,6 +306,31 @@
   color: var(--cherry-bright);
 }
 
+.slotListScroll {
+  max-height: 280px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.creativeBtn {
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  border: 1px dashed var(--charcoal-3);
+  border-radius: 10px;
+  background: var(--charcoal);
+  color: var(--beige-dim);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.creativeBtn:hover:not(:disabled) {
+  border-color: var(--cherry-bright);
+  color: var(--beige);
+}
+.creativeBtn:disabled { opacity: 0.6; cursor: wait; }
+
 .payNote {
   margin-top: 0.6rem;
   font-size: 0.74rem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "paths": { "@/*": ["./*"] }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "reference"]
+  "exclude": ["node_modules", "reference", "program"]
 }


### PR DESCRIPTION
## Summary

This PR transitions the dApp from fully mocked stubs to a **hybrid MVP** with real Solana devnet payments, IPFS media storage via Pinata, and a database-free listing model. Listings are now discovered by scanning the treasury account's transaction history, with metadata pinned to IPFS and anchored on-chain via memo. The app remains fully functional in mock mode when keys are absent.

## Key Changes

- **Real SOL payments**: Implemented `sendTreasuryTx()` to transfer SOL to the treasury with on-chain memos describing bookings and listing registrations. Both create-listing and contract-signing flows now execute real transactions when a treasury address is configured.

- **Database-free listings**: Created `lib/listings.ts` to read listings by scanning the treasury account's transaction history, extracting metadata CIDs from memos, and resolving them from IPFS. Listings are discovered on-chain; no backend database needed.

- **IPFS integration**: Wired real Pinata uploads via server-side `/api/upload` and `/api/pin-json` routes (keeping the JWT off the client). File validation is performed server-side before pinning. Falls back to mock CIDs when `PINATA_JWT` is absent.

- **Configuration & feature flags**: Centralized runtime config in `lib/config.ts` with environment-based feature flags. `PAYMENTS_ENABLED` and `SUPABASE_ENABLED` automatically activate when their env vars are set, allowing the app to degrade gracefully to mock mode.

- **Real wallet balance & user listings**: Updated dashboard to fetch actual SOL balance via `getBalance()` and user's on-chain listings via `getUserListings()`.

- **Booking & listing memos**: Defined structured memo formats (`bookingMemo()`, `listingMemo()`) so transactions are auditable and indexable on-chain without a database.

- **Explorer links**: Added `lib/explorer.ts` to generate cluster-aware Solana Explorer URLs for transactions and addresses.

- **Updated create-listing & contract flows**: Both now pin metadata to IPFS, construct memos, and send real treasury transactions when payments are enabled. UI shows appropriate messaging for mock vs. live mode.

- **Documentation**: Added `docs/BACKEND-SETUP.md` with step-by-step instructions for obtaining a treasury address and Pinata JWT, emphasizing that only public values and one API key are needed.

## Notable Implementation Details

- **Graceful degradation**: Every integration (Solana, IPFS, treasury) is optional. The app runs fully in mock mode locally with zero setup; adding env vars flips features live without code changes.

- **Source of truth = chain + IPFS**: Listing metadata lives on IPFS (content-addressed, tamper-evident); the CID is anchored on-chain via a registration transaction. The treasury account's transaction history is the on-chain registry—no separate indexer or database required.

- **Server-side secret handling**: Pinata JWT and other secrets are read only inside server routes (`/api/upload`, `/api/pin-json`), never bundled into the browser.

- **Memo-based discovery**: Listings and bookings are discovered by parsing transaction memos. This makes them auditable and queryable without a backend, and allows future indexers to build on the same data.

- **Real wallet integration**: The dApp now uses the connected wallet's public key for ownership and sends transactions via the wallet adapter's `sendTransaction()` callback.

https://claude.ai/code/session_01FLADEB3tSdzEV1EMPsUJXb